### PR TITLE
bumping reqs and adding metadata to endpoint

### DIFF
--- a/materializationengine/blueprints/client/api.py
+++ b/materializationengine/blueprints/client/api.py
@@ -354,6 +354,11 @@ class FrozenTableMetadata(Resource):
         schema = AnalysisTableSchema()
         tables = schema.dump(analysis_table)
 
+        db = dynamic_annotation_cache.get_db(aligned_volume_name)
+        ann_md = db.get_table_metadata(table_name)
+        ann_md.pop('id')
+        ann_md.pop('deleted')
+        tables.update(ann_md)
         return tables, 200
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 emannotationschemas==3.2.0
-annotationframeworkclient==2.4.0
+annotationframeworkclient==3.2.0
 cloud-volume==3.14.0
 cloud-files==1.28.1
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ amqp==2.6.1
     # via kombu
 aniso8601==9.0.1
     # via flask-restx
-annotationframeworkclient==2.4.0
+annotationframeworkclient==3.2.0
     # via -r requirements.txt
 async-timeout==3.0.1
     # via aiohttp


### PR DESCRIPTION
This will enable users to get all the relevant metadata from materialization without having to go back to the annotation engine for description and resolution. 