### PR TITLE
Mergeless materialization

### DIFF
--- a/materializationengine/celery_worker.py
+++ b/materializationengine/celery_worker.py
@@ -112,15 +112,18 @@ def setup_periodic_tasks(sender, **kwargs):
         run_periodic_materialization,
     )
 
+    merge_tables = get_config_param("MERGE_TABLES")
     periodic_tasks = {
         "run_daily_periodic_materialization": run_periodic_materialization.s(
-            days_to_expire=2
+            days_to_expire=2, merge_tables=merge_tables
         ),
         "run_weekly_periodic_materialization": run_periodic_materialization.s(
-            days_to_expire=7
+            days_to_expire=7, merge_tables=merge_tables
         ),
         "run_lts_periodic_materialization": run_periodic_materialization.s(
-            days_to_expire=days_till_next_month(datetime.datetime.utcnow())
+            days_to_expire=days_till_next_month(
+                datetime.datetime.utcnow(), merge_tables=merge_tables
+            )
         ),
         "run_periodic_database_update": run_periodic_database_update.s(),
         "remove_expired_databases": remove_expired_databases.s(

--- a/materializationengine/celery_worker.py
+++ b/materializationengine/celery_worker.py
@@ -122,8 +122,9 @@ def setup_periodic_tasks(sender, **kwargs):
         ),
         "run_lts_periodic_materialization": run_periodic_materialization.s(
             days_to_expire=days_till_next_month(
-                datetime.datetime.utcnow(), merge_tables=merge_tables
-            )
+                datetime.datetime.utcnow(),
+            ),
+            merge_tables=merge_tables,
         ),
         "run_periodic_database_update": run_periodic_database_update.s(),
         "remove_expired_databases": remove_expired_databases.s(

--- a/materializationengine/config.py
+++ b/materializationengine/config.py
@@ -39,6 +39,7 @@ class BaseConfig:
     INFO_API_VERSION = 2
     MIN_DATABASES = 2
     MAX_DATABASES = 2
+    MERGE_TABLES = True
     AUTH_SERVICE_NAMESPACE = "datastack"
     if os.environ.get("DAF_CREDENTIALS", None) is not None:
         with open(os.environ.get("DAF_CREDENTIALS"), "r") as f:

--- a/materializationengine/workflows/create_frozen_database.py
+++ b/materializationengine/workflows/create_frozen_database.py
@@ -51,7 +51,9 @@ celery_logger = get_task_logger(__name__)
 
 
 @celery.task(name="workflow:materialize_database")
-def materialize_database(days_to_expire: int = 5, **kwargs) -> None:
+def materialize_database(
+    days_to_expire: int = 5, merge_tables: bool = True, **kwargs
+) -> None:
     """
     Materialize database. Steps are as follows:
     1. Create new versioned database.
@@ -71,7 +73,7 @@ def materialize_database(days_to_expire: int = 5, **kwargs) -> None:
             celery_logger.info(f"Materializing {datastack} database")
             datastack_info = get_datastack_info(datastack)
             task = create_versioned_materialization_workflow.s(
-                datastack_info, days_to_expire
+                datastack_info, days_to_expire, merge_tables
             )
             task.apply_async(kwargs={"Datastack": datastack_info["datastack"]})
         except Exception as e:
@@ -82,7 +84,7 @@ def materialize_database(days_to_expire: int = 5, **kwargs) -> None:
 
 @celery.task(name="workflow:create_versioned_materialization_workflow")
 def create_versioned_materialization_workflow(
-    datastack_info: dict, days_to_expire: int = 5, **kwargs
+    datastack_info: dict, days_to_expire: int = 5, merge_tables: bool = True, **kwargs
 ):
     """Create a timelocked database of materialization annotations
     and associated segmentation data.
@@ -104,12 +106,17 @@ def create_versioned_materialization_workflow(
     setup_versioned_database = create_materialized_database_workflow(
         datastack_info, new_version_number, materialization_time_stamp, mat_info
     )
-    format_workflow = format_materialization_database_workflow(mat_info)
+    if merge_tables:
+        format_workflow = format_materialization_database_workflow(mat_info)
 
+        analysis_database_workflow = chain(
+            chord(format_workflow, fin.s()), rebuild_reference_tables.si(mat_info)
+        )
+    else:
+        analysis_database_workflow = fin.si()
     workflow = chain(
         setup_versioned_database,
-        chord(format_workflow, fin.s()),
-        rebuild_reference_tables.si(mat_info),
+        analysis_database_workflow,
         check_tables.si(mat_info, new_version_number),
     )
 
@@ -165,7 +172,9 @@ def format_materialization_database_workflow(mat_info: List[dict]):
     """
     create_frozen_database_tasks = []
     for mat_metadata in mat_info:
-        if not mat_metadata["reference_table"]: # need to build tables before adding reference tables with fkeys
+        if not mat_metadata[
+            "reference_table"
+        ]:  # need to build tables before adding reference tables with fkeys
             create_frozen_database_workflow = chain(
                 merge_tables.si(mat_metadata), add_indices.si(mat_metadata)
             )
@@ -276,7 +285,7 @@ def create_new_version(
     max_retries=3,
 )
 def create_analysis_database(self, datastack_info: dict, analysis_version: int) -> str:
-    """Copies live database to new versioned database for materializied annotations.
+    """Copies live database to new versioned database for materialized annotations.
 
     Args:
         datastack_info (dict): datastack metadata

--- a/materializationengine/workflows/create_frozen_database.py
+++ b/materializationengine/workflows/create_frozen_database.py
@@ -101,7 +101,7 @@ def create_versioned_materialization_workflow(
         datastack_info, new_version_number, materialization_time_stamp
     )
 
-    setup_versioned_database = create_materializied_database_workflow(
+    setup_versioned_database = create_materialized_database_workflow(
         datastack_info, new_version_number, materialization_time_stamp, mat_info
     )
     format_workflow = format_materialization_database_workflow(mat_info)
@@ -116,13 +116,13 @@ def create_versioned_materialization_workflow(
     return workflow
 
 
-def create_materializied_database_workflow(
+def create_materialized_database_workflow(
     datastack_info: dict,
     new_version_number: int,
     materialization_time_stamp: datetime.datetime.utcnow,
     mat_info: List[dict],
 ):
-    """Celery workflow to create a materializied database.
+    """Celery workflow to create a materialized database.
 
     Workflow:
         - Copy live database as a versioned materialized database.

--- a/materializationengine/workflows/periodic_database_removal.py
+++ b/materializationengine/workflows/periodic_database_removal.py
@@ -77,7 +77,7 @@ def remove_expired_databases(delete_threshold: int = 5) -> str:
                 celery_logger.error(f"Error: {sql_error}")
                 continue
 
-            # get databases that exist currently, filter by materializied dbs
+            # get databases that exist currently, filter by materialized dbs
             database_list = get_existing_databases(engine)
 
             databases = [

--- a/materializationengine/workflows/periodic_materialization.py
+++ b/materializationengine/workflows/periodic_materialization.py
@@ -31,7 +31,7 @@ def run_periodic_materialization(
     2. Update expired root ids
     3. Copy database to new frozen version
     4. Merge annotation and segmentation tables together
-    5. Drop non-materializied tables
+    5. Drop non-materialized tables
     """
     is_update_roots_running = check_if_task_is_running(
         "workflow:update_database_workflow", "worker.workflow"

--- a/materializationengine/workflows/periodic_materialization.py
+++ b/materializationengine/workflows/periodic_materialization.py
@@ -22,7 +22,9 @@ def _get_datastacks() -> List:
 
 
 @celery.task(name="workflow:run_periodic_materialization")
-def run_periodic_materialization(days_to_expire: int = None) -> None:
+def run_periodic_materialization(
+    days_to_expire: int = None, merge_tables: bool = True
+) -> None:
     """
     Run complete materialization workflow. Steps are as follows:
     1. Find missing segmentation data in a given datastack and lookup.
@@ -61,7 +63,7 @@ def run_periodic_materialization(days_to_expire: int = None) -> None:
                 return f"Number of valid materialized databases is {valid_databases}, threshold is set to: {max_databases}"
             datastack_info["database_expires"] = True
             task = run_complete_workflow.s(
-                datastack_info, days_to_expire=days_to_expire
+                datastack_info, days_to_expire=days_to_expire, merge_tables=merge_tables
             )
             task.apply_async(kwargs={"Datastack": datastack})
         except Exception as e:


### PR DESCRIPTION
Setting up optional workflow to not merge tables during a frozen materialization. The goal of this is to eliminate the need to rebuild indexes after merging segmentation and annotation tables together.