### PR TITLE
Materialization fixes datastack counting

### DIFF
--- a/materializationengine/workflows/periodic_materialization.py
+++ b/materializationengine/workflows/periodic_materialization.py
@@ -56,6 +56,7 @@ def run_periodic_materialization(
             valid_databases = (
                 session.query(AnalysisVersion)
                 .filter(AnalysisVersion.valid == True)
+                .filter(AnalysisVersion.parent_version != None)
                 .order_by(AnalysisVersion.time_stamp)
                 .count()
             )

--- a/materializationengine/workflows/periodic_materialization.py
+++ b/materializationengine/workflows/periodic_materialization.py
@@ -56,6 +56,7 @@ def run_periodic_materialization(
             valid_databases = (
                 session.query(AnalysisVersion)
                 .filter(AnalysisVersion.valid == True)
+                .filter(AnalysisVersion.datastack == datastack)
                 .filter(AnalysisVersion.parent_version != None)
                 .order_by(AnalysisVersion.time_stamp)
                 .count()

--- a/materializationengine/workflows/update_root_ids.py
+++ b/materializationengine/workflows/update_root_ids.py
@@ -150,8 +150,6 @@ def lookup_expired_root_ids(
     pcg_table_name, last_updated_ts, materialization_time_stamp
 ):
     cg_client = chunkedgraph_cache.init_pcg(pcg_table_name)
-    if last_updated_ts is None:
-        last_updated_ts = cg_client.get_oldest_timestamp()
     try:
         old_roots, __ = cg_client.get_delta_roots(
             last_updated_ts, materialization_time_stamp

--- a/materializationengine/workflows/update_root_ids.py
+++ b/materializationengine/workflows/update_root_ids.py
@@ -150,6 +150,8 @@ def lookup_expired_root_ids(
     pcg_table_name, last_updated_ts, materialization_time_stamp
 ):
     cg_client = chunkedgraph_cache.init_pcg(pcg_table_name)
+    if last_updated_ts is None:
+        last_updated_ts = cg_client.get_oldest_timestamp()
     try:
         old_roots, __ = cg_client.get_delta_roots(
             last_updated_ts, materialization_time_stamp
@@ -189,7 +191,7 @@ def get_supervoxel_id_queries(root_id_chunk: list, mat_metadata: dict):
             SegmentationModel.id,
             root_id_att,
             sv_id_att,
-        ).filter(or_(or_(root_id_att).in_(root_id_chunk),root_id_att==None))
+        ).filter(or_(or_(root_id_att).in_(root_id_chunk), root_id_att == None))
 
         sv_ids_query = sv_ids_query.statement.compile(
             compile_kwargs={"literal_binds": True}

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-caveclient>=4.10.0
+caveclient>=5.1.0
 cloud-volume>=8.5.4
 pillow>=8.3.2
 psutil>=5.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ cachetools==5.0.0
     #   caveclient
     #   google-auth
     #   middle-auth-client
-caveclient==4.16.2
+caveclient==5.1.0
     # via -r requirements.in
 celery==5.2.5
     # via -r requirements.in


### PR DESCRIPTION
This fixes a bug where versions from other datastacks and virtual versions were counting toward the total number of versions.

This also attempts to make the lookup_expired_roots call with no starting timestamp work correctly by utilizing a new feature of the caveclient to query what the oldest timestamp is. 