### PR TITLE
removing auto version

### DIFF
--- a/materializationengine/blueprints/materialize/api.py
+++ b/materializationengine/blueprints/materialize/api.py
@@ -618,7 +618,7 @@ class CreateVirtualPublicVersionResource(Resource):
                 f"No tables {tables_to_include} found in target version {target_version}",
             )
 
-        virtual_datastack_name = f"{virtual_version_name}_v{analysis_version.version}"
+        virtual_datastack_name = f"{virtual_version_name}"
 
         time_to_expire = analysis_version.expires_on - datetime.datetime.utcnow()
         if time_to_expire.days < 1000:


### PR DESCRIPTION
I don't want it to auto add version numbers to things as I want to make minnie65_public and be able to use the endpoint to easily add tables to that datastack at different version levels.