### PR TITLE
adding retries to delete task to handle info service being down

### DIFF
--- a/materializationengine/workflows/periodic_database_removal.py
+++ b/materializationengine/workflows/periodic_database_removal.py
@@ -47,7 +47,11 @@ def get_valid_versions(session):
     return [str(version) for version in valid_versions]
 
 
-@celery.task(name="workflow:remove_expired_databases")
+@celery.task(name="workflow:remove_expired_databases",
+             bind=True,
+             acks_late=True,
+             autoretry_for=(Exception,),
+             max_retries=3)
 def remove_expired_databases(delete_threshold: int = 5, datastack: str = None) -> str:
     """Remove expired databases and clean up their metadata.
     


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves resilience of periodic database cleanup.
> 
> - Updates Celery task `workflow:remove_expired_databases` to `bind=True`, `acks_late=True`, `autoretry_for=(Exception,)`, `max_retries=3` for automatic retries and safer failure handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42eb69799b585ffa27b6e51aba6353b1c6447a45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->