### PR TITLE
Add admin facing UI for delta lake dump and spec configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ credentials.tar.gz
 *.pkl
 # ignore sentinel conf outputs
 *running.conf
+preview_ui.py

--- a/materializationengine/app.py
+++ b/materializationengine/app.py
@@ -3,7 +3,7 @@ import logging
 from datetime import date, datetime, timedelta
 
 import numpy as np
-from dynamicannotationdb.models import Base, AnalysisVersion
+from dynamicannotationdb.models import AnalysisVersion, Base
 from flask import Blueprint, Flask, current_app, jsonify, redirect, url_for
 from flask_cors import CORS
 from flask_restx import Api
@@ -13,18 +13,19 @@ from materializationengine import __version__
 from materializationengine.admin import setup_admin
 from materializationengine.blueprints.client.api import client_bp
 from materializationengine.blueprints.client.api2 import client_bp as client_bp2
+from materializationengine.blueprints.deltalake.api import deltalake_bp
 from materializationengine.blueprints.materialize.api import mat_bp
-from materializationengine.blueprints.upload.api import upload_bp, spatial_lookup_bp
-from materializationengine.blueprints.upload.storage import StorageService
+from materializationengine.blueprints.upload.api import spatial_lookup_bp, upload_bp
 from materializationengine.blueprints.upload.models import init_staging_database
+from materializationengine.blueprints.upload.storage import StorageService
 from materializationengine.config import config, configure_app
 from materializationengine.database import db_manager
-from materializationengine.schemas import ma
-from materializationengine.utils import get_instance_folder_path
-from materializationengine.views import views_bp
 from materializationengine.limiter import limiter
 from materializationengine.migrate import migrator
 from materializationengine.request_db import init_request_db_cleanup
+from materializationengine.schemas import ma
+from materializationengine.utils import get_instance_folder_path
+from materializationengine.views import views_bp
 
 db = SQLAlchemy(model_class=Base)
 
@@ -53,7 +54,7 @@ def create_app(config_name: str = None):
         template_folder="../templates",
     )
     CORS(app, expose_headers=["WWW-Authenticate", "column_names"], send_wildcard=True)
-    
+
     app.json_encoder = AEEncoder
     app.config["RESTX_JSON"] = {"cls": AEEncoder}
 
@@ -62,19 +63,19 @@ def create_app(config_name: str = None):
         app.config.from_object(config[config_name])
     else:
         app = configure_app(app)
-    logging.basicConfig(level=app.config['LOGGING_LEVEL'])
-    
+    logging.basicConfig(level=app.config["LOGGING_LEVEL"])
+
     # Suppress noisy debug messages from fsevents
-    logging.getLogger('fsevents').setLevel(app.config['LOGGING_LEVEL'])
-    logging.getLogger('urllib3').setLevel(app.config['LOGGING_LEVEL'])
-    logging.getLogger('google').setLevel(app.config['LOGGING_LEVEL'])
-    logging.getLogger('materializationengine').setLevel(app.config['LOGGING_LEVEL'])
-    logging.getLogger('root').setLevel(app.config['LOGGING_LEVEL'])
-    logging.getLogger('python_jsonschema_objects').setLevel(app.config['LOGGING_LEVEL'])
+    logging.getLogger("fsevents").setLevel(app.config["LOGGING_LEVEL"])
+    logging.getLogger("urllib3").setLevel(app.config["LOGGING_LEVEL"])
+    logging.getLogger("google").setLevel(app.config["LOGGING_LEVEL"])
+    logging.getLogger("materializationengine").setLevel(app.config["LOGGING_LEVEL"])
+    logging.getLogger("root").setLevel(app.config["LOGGING_LEVEL"])
+    logging.getLogger("python_jsonschema_objects").setLevel(app.config["LOGGING_LEVEL"])
 
     # Initialize request-scoped database session cleanup
     init_request_db_cleanup(app)
-    
+
     # register blueprints
     apibp = Blueprint("api", __name__, url_prefix="/materialize")
 
@@ -90,9 +91,9 @@ def create_app(config_name: str = None):
     def index():
         return redirect("/materialize/views/")
 
-    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
-        'pool_pre_ping': True,
-        'pool_recycle': 3600,
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
+        "pool_pre_ping": True,
+        "pool_recycle": 3600,
     }
 
     db.init_app(app)
@@ -116,16 +117,17 @@ def create_app(config_name: str = None):
         app.register_blueprint(apibp)
         app.register_blueprint(views_bp)
         app.register_blueprint(upload_bp)
+        app.register_blueprint(deltalake_bp)
         limiter.init_app(app)
         try:
             db.create_all()
         except Exception as e:
             app.logger.error(f"Error creating database tables: {e}")
-            
+
         admin = setup_admin(app, db)
         if app.config.get("STAGING_DATABASE_NAME"):
             init_staging_database(app)
-            
+
         # setup cors on upload bucket
         try:
             bucket_name = app.config.get("MATERIALIZATION_UPLOAD_BUCKET_PATH")
@@ -139,10 +141,11 @@ def create_app(config_name: str = None):
         aligned_volume = current_app.config.get("TEST_DB_NAME", "annotation")
         with db_manager.session_scope(aligned_volume) as session:
             n_versions = session.query(AnalysisVersion).count()
-        
+
         return jsonify({aligned_volume: n_versions}), 200
 
     @app.teardown_appcontext
     def shutdown_session(exception=None):
         db_manager.cleanup()
+
     return app

--- a/materializationengine/blueprints/deltalake/__init__.py
+++ b/materializationengine/blueprints/deltalake/__init__.py
@@ -1,0 +1,3 @@
+from materializationengine.blueprints.deltalake.api import deltalake_bp
+
+__all__ = ["deltalake_bp"]

--- a/materializationengine/blueprints/deltalake/api.py
+++ b/materializationengine/blueprints/deltalake/api.py
@@ -298,7 +298,7 @@ def discover_specs():
 
 @deltalake_bp.route("/api/check-exists", methods=["POST"])
 @reset_auth
-@auth_required
+@auth_requires_admin
 def check_exists():
     """Check whether Delta Lake exports already exist for a table/version.
 
@@ -321,6 +321,15 @@ def check_exists():
             {"error": "datastack, version, and table_name are required"}
         ), 400
 
+    from materializationengine.workflows.deltalake_export import _validate_identifier
+
+    try:
+        _validate_identifier(datastack)
+        _validate_identifier(table_name)
+        version = int(version)
+    except (ValueError, TypeError):
+        return jsonify({"error": "Invalid datastack, version, or table_name"}), 400
+
     output_bucket = get_config_param("DELTALAKE_OUTPUT_BUCKET", "")
     if not output_bucket:
         return jsonify({"error": "DELTALAKE_OUTPUT_BUCKET not configured"}), 500
@@ -331,6 +340,11 @@ def check_exists():
     # Otherwise fall back to cached specs or just check "flat".
     spec_names = data.get("spec_names")
     if spec_names:
+        try:
+            for sn in spec_names:
+                _validate_identifier(sn)
+        except (ValueError, TypeError):
+            return jsonify({"error": "Invalid spec_names entry"}), 400
         partition_names = list(set(spec_names))
     else:
         from materializationengine.workflows.deltalake_export import _get_redis_client

--- a/materializationengine/blueprints/deltalake/api.py
+++ b/materializationengine/blueprints/deltalake/api.py
@@ -1,0 +1,283 @@
+import json
+import os
+
+from flask import (
+    Blueprint,
+    current_app,
+    g,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from middle_auth_client import auth_required, auth_requires_admin
+
+from materializationengine.blueprints.reset_auth import reset_auth
+from materializationengine.info_client import get_datastack_info, get_datastacks
+from materializationengine.utils import get_config_param
+
+deltalake_bp = Blueprint(
+    "deltalake",
+    __name__,
+    url_prefix="/materialize/deltalake",
+)
+
+
+def _is_auth_disabled():
+    return current_app.config.get(
+        "AUTH_DISABLED",
+        os.environ.get("AUTH_DISABLED", "").lower() in ("true", "1", "yes"),
+    )
+
+
+def _has_datastack_permission(auth_user_info, permission_level, datastack_name):
+    if not auth_user_info or not datastack_name or not permission_level:
+        return False
+    permissions = auth_user_info.get("permissions", [])
+    required_permission = f"{datastack_name.lower()}_{permission_level.lower()}"
+    return required_permission in permissions
+
+
+# ---------------------------------------------------------------------------
+# Wizard page routes
+# ---------------------------------------------------------------------------
+
+
+@deltalake_bp.route("/")
+@reset_auth
+@auth_requires_admin
+def index():
+    """Redirect to step 1 of the wizard."""
+    return redirect(url_for("deltalake.wizard_step", step_number=1))
+
+
+@deltalake_bp.route("/step<int:step_number>")
+@reset_auth
+@auth_requires_admin
+def wizard_step(step_number):
+    total_steps = 3
+
+    if step_number < 1 or step_number > total_steps:
+        return redirect(url_for("deltalake.wizard_step", step_number=1))
+
+    try:
+        all_datastacks = get_datastacks() or []
+        if _is_auth_disabled() or not g.get("auth_user"):
+            datastacks = sorted(all_datastacks)
+        else:
+            datastacks = sorted(
+                ds
+                for ds in all_datastacks
+                if _has_datastack_permission(g.auth_user, "admin", ds)
+            )
+    except Exception as e:
+        current_app.logger.error(
+            f"Failed to get datastacks for deltalake wizard step {step_number}: {e}",
+            exc_info=True,
+        )
+        datastacks = []
+
+    step_template_path = f"deltalake/step{step_number}.html"
+
+    return render_template(
+        "deltalake_wizard.html",
+        current_step=step_number,
+        total_steps=total_steps,
+        step_template=step_template_path,
+        datastacks=datastacks,
+        current_user=g.get("auth_user", {}),
+        target_partition_size_mb=get_config_param(
+            "DELTALAKE_TARGET_PARTITION_SIZE_MB", 256
+        ),
+        output_bucket=get_config_param("DELTALAKE_OUTPUT_BUCKET", ""),
+    )
+
+
+@deltalake_bp.route("/running-exports")
+@reset_auth
+@auth_required
+def running_exports_page():
+    """Render the running exports monitoring page."""
+    return render_template(
+        "deltalake/running_exports.html",
+        current_user=g.get("auth_user", {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# API routes
+# ---------------------------------------------------------------------------
+
+
+@deltalake_bp.route("/api/defaults", methods=["GET"])
+@reset_auth
+@auth_required
+def get_defaults():
+    """Return environment defaults for the wizard UI."""
+    return jsonify(
+        {
+            "target_partition_size_mb": int(
+                get_config_param("DELTALAKE_TARGET_PARTITION_SIZE_MB", 256)
+            ),
+            "output_bucket": get_config_param("DELTALAKE_OUTPUT_BUCKET", ""),
+        }
+    )
+
+
+@deltalake_bp.route("/api/discover-specs", methods=["POST"])
+@reset_auth
+@auth_requires_admin
+def discover_specs():
+    """Run spec discovery for a table without enqueuing an export.
+
+    Expects JSON body: { datastack, version, table_name, target_partition_size_mb }
+    Returns: { row_count, bytes_per_row, specs: [...] }
+    """
+    from dynamicannotationdb.key_utils import build_segmentation_table_name
+    from sqlalchemy import create_engine
+
+    from materializationengine.database import db_manager
+    from materializationengine.models import MaterializedMetadata
+    from materializationengine.workflows.deltalake_export import (
+        DeltaLakeOutputSpec,
+        TableSource,
+        _build_frozen_db_connection_string,
+        _get_redis_client,
+        discover_default_output_specs,
+        estimate_bytes_per_row,
+        resolve_n_partitions,
+    )
+
+    if not request.is_json or not request.json:
+        return jsonify({"error": "Request body must be JSON"}), 400
+
+    data = request.json
+    datastack = data.get("datastack")
+    version = data.get("version")
+    table_name = data.get("table_name")
+    target_partition_size_mb = data.get("target_partition_size_mb", 256)
+
+    if not all([datastack, version, table_name]):
+        return jsonify(
+            {"error": "datastack, version, and table_name are required"}
+        ), 400
+
+    # Check Redis cache first.
+    cache_key = f"deltalake_specs:{datastack}:v{version}:{table_name}"
+    redis_client = _get_redis_client()
+    cached = redis_client.get(cache_key)
+    if cached:
+        return jsonify(json.loads(cached))
+
+    try:
+        datastack_info = get_datastack_info(datastack)
+    except Exception as e:
+        return jsonify({"error": f"Datastack not found: {e}"}), 404
+
+    sql_uri_config = get_config_param("SQLALCHEMY_DATABASE_URI")
+    connection_string = _build_frozen_db_connection_string(
+        sql_uri_config, datastack, version
+    )
+
+    analysis_database = f"{datastack}__mat{version}"
+    pcg_table_name = datastack_info["segmentation_source"].split("/")[-1]
+
+    try:
+        engine = db_manager.get_engine(analysis_database)
+    except Exception as e:
+        return jsonify(
+            {"error": f"Cannot connect to frozen DB for version {version}: {e}"}
+        ), 404
+
+    # Look up row count.
+    with db_manager.session_scope(analysis_database) as session:
+        metadata_row = (
+            session.query(MaterializedMetadata)
+            .filter(MaterializedMetadata.table_name == table_name)
+            .first()
+        )
+        if metadata_row is None:
+            return jsonify(
+                {"error": f"Table {table_name!r} not found in version {version}"}
+            ), 404
+        row_count = metadata_row.row_count
+
+    # Detect segmentation table.
+    seg_table_name = build_segmentation_table_name(table_name, pcg_table_name)
+    has_seg_table = engine.dialect.has_table(engine, seg_table_name)
+    segmentation_table_name = seg_table_name if has_seg_table else None
+
+    source = TableSource(
+        annotation_table=table_name,
+        segmentation_table=segmentation_table_name,
+    )
+
+    # Discover specs.
+    resolved_specs = discover_default_output_specs(source, engine)
+    bytes_per_row = estimate_bytes_per_row(connection_string, source)
+
+    # Resolve partition counts.
+    for spec in resolved_specs:
+        if spec.n_partitions == "auto":
+            effective_target = spec.target_file_size_mb or target_partition_size_mb
+            spec.n_partitions = resolve_n_partitions(
+                "auto",
+                row_count,
+                target_file_size_mb=effective_target,
+                bytes_per_row=bytes_per_row,
+            )
+
+    from dataclasses import asdict
+
+    result = {
+        "row_count": row_count,
+        "bytes_per_row": bytes_per_row,
+        "specs": [asdict(s) for s in resolved_specs],
+    }
+
+    # Cache in Redis with 10-minute TTL.
+    redis_client.set(cache_key, json.dumps(result), ex=600)
+
+    return jsonify(result)
+
+
+@deltalake_bp.route("/api/recalculate", methods=["POST"])
+@reset_auth
+@auth_required
+def recalculate():
+    """Recompute n_partitions for specs. Pure computation, no DB access.
+
+    Expects JSON body: { row_count, bytes_per_row, specs: [...] }
+    Returns: { specs: [...with recomputed n_partitions...] }
+    """
+    from materializationengine.workflows.deltalake_export import resolve_n_partitions
+
+    if not request.is_json or not request.json:
+        return jsonify({"error": "Request body must be JSON"}), 400
+
+    data = request.json
+    row_count = data.get("row_count")
+    bytes_per_row = data.get("bytes_per_row")
+    specs = data.get("specs")
+
+    if not all([row_count, bytes_per_row, specs]):
+        return jsonify(
+            {"error": "row_count, bytes_per_row, and specs are required"}
+        ), 400
+
+    global_target = int(get_config_param("DELTALAKE_TARGET_PARTITION_SIZE_MB", 256))
+
+    result_specs = []
+    for spec in specs:
+        if spec.get("n_partitions") == "auto" or spec.get("n_partitions") is None:
+            effective_target = spec.get("target_file_size_mb") or global_target
+            spec["n_partitions"] = resolve_n_partitions(
+                "auto",
+                row_count,
+                target_file_size_mb=effective_target,
+                bytes_per_row=bytes_per_row,
+            )
+        result_specs.append(spec)
+
+    return jsonify({"specs": result_specs})

--- a/materializationengine/blueprints/deltalake/api.py
+++ b/materializationengine/blueprints/deltalake/api.py
@@ -296,50 +296,6 @@ def discover_specs():
     return jsonify(result)
 
 
-@deltalake_bp.route("/api/recalculate", methods=["POST"])
-@reset_auth
-@auth_required
-def recalculate():
-    """Recompute n_partitions for specs. Pure computation, no DB access.
-
-    Expects JSON body: { row_count, bytes_per_row, specs: [...] }
-    Returns: { specs: [...with recomputed n_partitions...] }
-    """
-    from materializationengine.workflows.deltalake_export import resolve_n_partitions
-
-    if not request.is_json or not request.json:
-        return jsonify({"error": "Request body must be JSON"}), 400
-
-    data = request.json
-    row_count = data.get("row_count")
-    bytes_per_row = data.get("bytes_per_row")
-    specs = data.get("specs")
-
-    if not all([row_count, bytes_per_row, specs]):
-        return jsonify(
-            {"error": "row_count, bytes_per_row, and specs are required"}
-        ), 400
-
-    global_target = int(get_config_param("DELTALAKE_TARGET_PARTITION_SIZE_MB", 256))
-    user_target = data.get("target_partition_size_mb")
-    if user_target is not None:
-        global_target = int(user_target)
-
-    result_specs = []
-    for spec in specs:
-        if spec.get("n_partitions") == "auto" or spec.get("n_partitions") is None:
-            effective_target = spec.get("target_file_size_mb") or global_target
-            spec["n_partitions"] = resolve_n_partitions(
-                "auto",
-                row_count,
-                target_file_size_mb=effective_target,
-                bytes_per_row=bytes_per_row,
-            )
-        result_specs.append(spec)
-
-    return jsonify({"specs": result_specs})
-
-
 @deltalake_bp.route("/api/check-exists", methods=["POST"])
 @reset_auth
 @auth_required

--- a/materializationengine/blueprints/deltalake/api.py
+++ b/materializationengine/blueprints/deltalake/api.py
@@ -83,6 +83,9 @@ def wizard_step(step_number):
         target_partition_size_mb=get_config_param(
             "DELTALAKE_TARGET_PARTITION_SIZE_MB", 256
         ),
+        bloom_filter_fpp=get_config_param(
+            "DELTALAKE_BLOOM_FILTER_FPP", 0.001
+        ),
         output_bucket=get_config_param("DELTALAKE_OUTPUT_BUCKET", ""),
     )
 
@@ -114,6 +117,9 @@ def get_defaults():
                 get_config_param("DELTALAKE_TARGET_PARTITION_SIZE_MB", 256)
             ),
             "output_bucket": get_config_param("DELTALAKE_OUTPUT_BUCKET", ""),
+            "bloom_filter_fpp": float(
+                get_config_param("DELTALAKE_BLOOM_FILTER_FPP", 0.001)
+            ),
         }
     )
 
@@ -135,8 +141,10 @@ def discover_specs():
     from materializationengine.workflows.deltalake_export import (
         DeltaLakeOutputSpec,
         TableSource,
+        _DEFAULT_DROP_COLUMNS,
         _build_frozen_db_connection_string,
         _get_redis_client,
+        _resolve_select_columns,
         discover_default_output_specs,
         estimate_bytes_per_row,
         resolve_n_partitions,
@@ -223,9 +231,22 @@ def discover_specs():
 
     from dataclasses import asdict
 
+    # Build available columns list (base columns + computed columns from specs).
+    available_columns = _resolve_select_columns(
+        connection_string, source, _DEFAULT_DROP_COLUMNS
+    )
+    for spec in resolved_specs:
+        if spec.source_geometry_column:
+            col = spec.source_geometry_column
+            for suffix in ["_x", "_y", "_z", "_morton"]:
+                computed = f"{col}{suffix}"
+                if computed not in available_columns:
+                    available_columns.append(computed)
+
     result = {
         "row_count": row_count,
         "bytes_per_row": bytes_per_row,
+        "available_columns": available_columns,
         "specs": [asdict(s) for s in resolved_specs],
     }
 

--- a/materializationengine/blueprints/deltalake/api.py
+++ b/materializationengine/blueprints/deltalake/api.py
@@ -83,9 +83,7 @@ def wizard_step(step_number):
         target_partition_size_mb=get_config_param(
             "DELTALAKE_TARGET_PARTITION_SIZE_MB", 256
         ),
-        bloom_filter_fpp=get_config_param(
-            "DELTALAKE_BLOOM_FILTER_FPP", 0.001
-        ),
+        bloom_filter_fpp=get_config_param("DELTALAKE_BLOOM_FILTER_FPP", 0.001),
         output_bucket=get_config_param("DELTALAKE_OUTPUT_BUCKET", ""),
     )
 
@@ -139,9 +137,9 @@ def discover_specs():
     from materializationengine.database import db_manager
     from materializationengine.models import MaterializedMetadata
     from materializationengine.workflows.deltalake_export import (
+        _DEFAULT_DROP_COLUMNS,
         DeltaLakeOutputSpec,
         TableSource,
-        _DEFAULT_DROP_COLUMNS,
         _build_frozen_db_connection_string,
         _get_redis_client,
         _resolve_select_columns,

--- a/materializationengine/blueprints/deltalake/api.py
+++ b/materializationengine/blueprints/deltalake/api.py
@@ -293,3 +293,75 @@ def recalculate():
         result_specs.append(spec)
 
     return jsonify({"specs": result_specs})
+
+
+@deltalake_bp.route("/api/check-exists", methods=["POST"])
+@reset_auth
+@auth_required
+def check_exists():
+    """Check whether Delta Lake exports already exist for a table/version.
+
+    Expects JSON body: { datastack, version, table_name }
+    Returns: { exists: bool, existing_specs: [{partition_by, uri, row_count}] }
+
+    This checks each potential output spec URI by attempting to open it as a
+    DeltaTable.  Returns per-spec existence info to support future selective
+    re-export flows.
+    """
+    if not request.is_json or not request.json:
+        return jsonify({"error": "Request body must be JSON"}), 400
+
+    data = request.json
+    datastack = data.get("datastack")
+    version = data.get("version")
+    table_name = data.get("table_name")
+
+    if not all([datastack, version, table_name]):
+        return jsonify(
+            {"error": "datastack, version, and table_name are required"}
+        ), 400
+
+    output_bucket = get_config_param("DELTALAKE_OUTPUT_BUCKET", "")
+    if not output_bucket:
+        return jsonify({"error": "DELTALAKE_OUTPUT_BUCKET not configured"}), 500
+
+    output_uri_base = f"{output_bucket}/{datastack}/v{version}/{table_name}"
+
+    # Check a set of common partition names.  If cached specs exist in Redis,
+    # use those partition_by values; otherwise check "flat" as the default.
+    from materializationengine.workflows.deltalake_export import _get_redis_client
+
+    redis_client = _get_redis_client()
+    cache_key = f"deltalake_specs:{datastack}:v{version}:{table_name}"
+    cached = redis_client.get(cache_key)
+
+    partition_names = ["flat"]
+    if cached:
+        import json as _json
+
+        cached_data = _json.loads(cached)
+        partition_names = list(
+            {
+                spec.get("partition_by") or "flat"
+                for spec in cached_data.get("specs", [])
+            }
+        )
+
+    existing_specs = []
+    for lake_name in partition_names:
+        uri = f"{output_uri_base}/{lake_name}"
+        try:
+            from deltalake import DeltaTable
+
+            dt = DeltaTable(uri)
+            row_count = dt.count()
+            existing_specs.append(
+                {"partition_by": lake_name, "uri": uri, "row_count": row_count}
+            )
+        except Exception:
+            # Table doesn't exist at this URI — not an error.
+            pass
+
+    return jsonify(
+        {"exists": len(existing_specs) > 0, "existing_specs": existing_specs}
+    )

--- a/materializationengine/blueprints/deltalake/api.py
+++ b/materializationengine/blueprints/deltalake/api.py
@@ -90,7 +90,7 @@ def wizard_step(step_number):
 
 @deltalake_bp.route("/running-exports")
 @reset_auth
-@auth_required
+@auth_requires_admin
 def running_exports_page():
     """Render the running exports monitoring page."""
     return render_template(
@@ -132,17 +132,16 @@ def discover_specs():
     Returns: { row_count, bytes_per_row, specs: [...] }
     """
     from dynamicannotationdb.key_utils import build_segmentation_table_name
-    from sqlalchemy import create_engine
 
     from materializationengine.database import db_manager
     from materializationengine.models import MaterializedMetadata
     from materializationengine.workflows.deltalake_export import (
         _DEFAULT_DROP_COLUMNS,
-        DeltaLakeOutputSpec,
         TableSource,
         _build_frozen_db_connection_string,
         _get_redis_client,
         _resolve_select_columns,
+        _validate_identifier,
         discover_default_output_specs,
         estimate_bytes_per_row,
         resolve_n_partitions,
@@ -162,12 +161,31 @@ def discover_specs():
             {"error": "datastack, version, and table_name are required"}
         ), 400
 
+    try:
+        _validate_identifier(table_name)
+    except ValueError:
+        return jsonify({"error": f"Invalid table name: {table_name!r}"}), 400
+
     # Check Redis cache first.
     cache_key = f"deltalake_specs:{datastack}:v{version}:{table_name}"
     redis_client = _get_redis_client()
     cached = redis_client.get(cache_key)
     if cached:
-        return jsonify(json.loads(cached))
+        cached_data = json.loads(cached)
+        # Cached data contains raw specs (n_partitions still "auto").
+        # Resolve partition counts per-request using the caller's target.
+        for spec in cached_data["specs"]:
+            if spec.get("n_partitions") == "auto" or spec.get("n_partitions") is None:
+                effective_target = (
+                    spec.get("target_file_size_mb") or target_partition_size_mb
+                )
+                spec["n_partitions"] = resolve_n_partitions(
+                    "auto",
+                    cached_data["row_count"],
+                    target_file_size_mb=effective_target,
+                    bytes_per_row=cached_data["bytes_per_row"],
+                )
+        return jsonify(cached_data)
 
     try:
         datastack_info = get_datastack_info(datastack)
@@ -216,6 +234,9 @@ def discover_specs():
     resolved_specs = discover_default_output_specs(source, engine)
     bytes_per_row = estimate_bytes_per_row(connection_string, source)
 
+    # Track which specs had "auto" before resolution (for caching).
+    was_auto = [spec.n_partitions == "auto" for spec in resolved_specs]
+
     # Resolve partition counts.
     for spec in resolved_specs:
         if spec.n_partitions == "auto":
@@ -241,15 +262,29 @@ def discover_specs():
                 if computed not in available_columns:
                     available_columns.append(computed)
 
+    # Cache raw specs (before n_partitions resolution) so the cache stays
+    # valid regardless of the caller's target_partition_size_mb.
+    raw_specs = [asdict(s) for s in resolved_specs]
+    # Reset resolved n_partitions back to "auto" for specs that were auto.
+    for raw, auto in zip(raw_specs, was_auto):
+        if auto:
+            raw["n_partitions"] = "auto"
+
+    cache_result = {
+        "row_count": row_count,
+        "bytes_per_row": bytes_per_row,
+        "available_columns": available_columns,
+        "specs": raw_specs,
+    }
+    redis_client.set(cache_key, json.dumps(cache_result), ex=600)
+
+    # Return the result with resolved partition counts.
     result = {
         "row_count": row_count,
         "bytes_per_row": bytes_per_row,
         "available_columns": available_columns,
         "specs": [asdict(s) for s in resolved_specs],
     }
-
-    # Cache in Redis with 10-minute TTL.
-    redis_client.set(cache_key, json.dumps(result), ex=600)
 
     return jsonify(result)
 
@@ -279,6 +314,9 @@ def recalculate():
         ), 400
 
     global_target = int(get_config_param("DELTALAKE_TARGET_PARTITION_SIZE_MB", 256))
+    user_target = data.get("target_partition_size_mb")
+    if user_target is not None:
+        global_target = int(user_target)
 
     result_specs = []
     for spec in specs:
@@ -301,12 +339,11 @@ def recalculate():
 def check_exists():
     """Check whether Delta Lake exports already exist for a table/version.
 
-    Expects JSON body: { datastack, version, table_name }
-    Returns: { exists: bool, existing_specs: [{partition_by, uri, row_count}] }
+    Expects JSON body: { datastack, version, table_name, spec_names? }
+    Returns: { exists: bool, existing_specs: [{name, uri, row_count}] }
 
-    This checks each potential output spec URI by attempting to open it as a
-    DeltaTable.  Returns per-spec existence info to support future selective
-    re-export flows.
+    If ``spec_names`` is provided, checks those exact folder names.
+    Otherwise falls back to cached specs or checks "flat".
     """
     if not request.is_json or not request.json:
         return jsonify({"error": "Request body must be JSON"}), 400
@@ -327,25 +364,26 @@ def check_exists():
 
     output_uri_base = f"{output_bucket}/{datastack}/v{version}/{table_name}"
 
-    # Check a set of common partition names.  If cached specs exist in Redis,
-    # use those partition_by values; otherwise check "flat" as the default.
-    from materializationengine.workflows.deltalake_export import _get_redis_client
+    # If the caller provides explicit spec names, use those.
+    # Otherwise fall back to cached specs or just check "flat".
+    spec_names = data.get("spec_names")
+    if spec_names:
+        partition_names = list(set(spec_names))
+    else:
+        from materializationengine.workflows.deltalake_export import _get_redis_client
 
-    redis_client = _get_redis_client()
-    cache_key = f"deltalake_specs:{datastack}:v{version}:{table_name}"
-    cached = redis_client.get(cache_key)
+        redis_client = _get_redis_client()
+        cache_key = f"deltalake_specs:{datastack}:v{version}:{table_name}"
+        cached = redis_client.get(cache_key)
 
-    partition_names = ["flat"]
-    if cached:
-        import json as _json
+        partition_names = ["flat"]
+        if cached:
+            import json as _json
 
-        cached_data = _json.loads(cached)
-        partition_names = list(
-            {
-                spec.get("partition_by") or "flat"
-                for spec in cached_data.get("specs", [])
-            }
-        )
+            cached_data = _json.loads(cached)
+            partition_names = list(
+                {spec.get("name") or "flat" for spec in cached_data.get("specs", [])}
+            )
 
     existing_specs = []
     for lake_name in partition_names:
@@ -356,7 +394,7 @@ def check_exists():
             dt = DeltaTable(uri)
             row_count = dt.count()
             existing_specs.append(
-                {"partition_by": lake_name, "uri": uri, "row_count": row_count}
+                {"name": lake_name, "uri": uri, "row_count": row_count}
             )
         except Exception:
             # Table doesn't exist at this URI — not an error.

--- a/materializationengine/blueprints/deltalake/api.py
+++ b/materializationengine/blueprints/deltalake/api.py
@@ -62,15 +62,8 @@ def wizard_step(step_number):
         return redirect(url_for("deltalake.wizard_step", step_number=1))
 
     try:
-        all_datastacks = get_datastacks() or []
-        if _is_auth_disabled() or not g.get("auth_user"):
-            datastacks = sorted(all_datastacks)
-        else:
-            datastacks = sorted(
-                ds
-                for ds in all_datastacks
-                if _has_datastack_permission(g.auth_user, "admin", ds)
-            )
+        datastacks = get_datastacks() or []
+        datastacks.sort()
     except Exception as e:
         current_app.logger.error(
             f"Failed to get datastacks for deltalake wizard step {step_number}: {e}",

--- a/materializationengine/blueprints/deltalake/api.py
+++ b/materializationengine/blueprints/deltalake/api.py
@@ -262,6 +262,11 @@ def discover_specs():
                 if computed not in available_columns:
                     available_columns.append(computed)
 
+    # Collect geometry columns (position columns that get morton-encoded).
+    geometry_columns = sorted(
+        {s.source_geometry_column for s in resolved_specs if s.source_geometry_column}
+    )
+
     # Cache raw specs (before n_partitions resolution) so the cache stays
     # valid regardless of the caller's target_partition_size_mb.
     raw_specs = [asdict(s) for s in resolved_specs]
@@ -274,6 +279,7 @@ def discover_specs():
         "row_count": row_count,
         "bytes_per_row": bytes_per_row,
         "available_columns": available_columns,
+        "geometry_columns": geometry_columns,
         "specs": raw_specs,
     }
     redis_client.set(cache_key, json.dumps(cache_result), ex=600)
@@ -283,6 +289,7 @@ def discover_specs():
         "row_count": row_count,
         "bytes_per_row": bytes_per_row,
         "available_columns": available_columns,
+        "geometry_columns": geometry_columns,
         "specs": [asdict(s) for s in resolved_specs],
     }
 

--- a/materializationengine/blueprints/materialize/api.py
+++ b/materializationengine/blueprints/materialize/api.py
@@ -898,7 +898,7 @@ class WriteDeltalakeResource(Resource):
                     return abort(400, "each entry in output_specs must be an object")
                 try:
                     DeltaLakeOutputSpec(**item)
-                except TypeError as exc:
+                except (TypeError, ValueError) as exc:
                     return abort(400, f"invalid output_specs entry: {exc}")
 
         job_id = uuid.uuid4().hex

--- a/materializationengine/blueprints/materialize/api.py
+++ b/materializationengine/blueprints/materialize/api.py
@@ -870,6 +870,8 @@ class WriteDeltalakeResource(Resource):
             version (int): materialization version (-1 for latest)
             table_name (str): annotation table name to export
         """
+        import uuid
+
         from materializationengine.workflows.deltalake_export import (
             write_deltalake_table,
         )
@@ -899,12 +901,19 @@ class WriteDeltalakeResource(Resource):
                 except TypeError as exc:
                     return abort(400, f"invalid output_specs entry: {exc}")
 
+        job_id = uuid.uuid4().hex
+
         write_deltalake_table.s(
-            datastack_info, version, table_name, output_specs=output_specs
+            datastack_info,
+            version,
+            table_name,
+            output_specs=output_specs,
+            job_id=job_id,
         ).apply_async()
 
         return {
-            "message": f"Delta Lake export enqueued for {table_name} v{version}"
+            "message": f"Delta Lake export enqueued for {table_name} v{version}",
+            "job_id": job_id,
         }, 200
 
     @reset_auth
@@ -915,6 +924,10 @@ class WriteDeltalakeResource(Resource):
 
         Returns JSON with ``status``, ``rows_processed``, ``total_rows``,
         and ``percent_complete``.  Returns 404 if no export is tracked.
+
+        Accepts optional ``job_id`` query parameter to poll a specific
+        export job (required when multiple exports of the same table
+        may exist).
         """
         from materializationengine.workflows.deltalake_export import (
             get_deltalake_export_progress,
@@ -923,7 +936,11 @@ class WriteDeltalakeResource(Resource):
         if version == -1:
             version = get_latest_version(datastack_name)
 
-        progress = get_deltalake_export_progress(datastack_name, version, table_name)
+        job_id = request.args.get("job_id", None)
+
+        progress = get_deltalake_export_progress(
+            datastack_name, version, table_name, job_id=job_id
+        )
         if progress is None:
             return {
                 "message": f"No export progress found for {table_name} v{version}"

--- a/materializationengine/workflows/deltalake_export.py
+++ b/materializationengine/workflows/deltalake_export.py
@@ -67,7 +67,7 @@ class TableSource:
 
 @dataclass
 class DeltaLakeOutputSpec:
-    name: str | None = None
+    name: str
     partition_by: str | None = None
     partition_strategy: Literal["percentile_range", "uniform_range", "hash"] | None = (
         None
@@ -80,6 +80,10 @@ class DeltaLakeOutputSpec:
     source_table: str | None = None
     bounds: list | None = None
     target_file_size_mb: int | None = None
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError("DeltaLakeOutputSpec.name must be a non-empty string")
 
 
 _IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_$]*$")
@@ -995,8 +999,7 @@ def _flush_buffer(
                 partition_by = [f"{part_col}_partition"]
 
         # Build the URI for this particular Delta Lake.
-        lake_name = spec.partition_by or "flat"
-        uri = f"{output_uri_base}/{lake_name}"
+        uri = f"{output_uri_base}/{spec.name}"
 
         write_deltalake(
             uri,
@@ -1102,11 +1105,10 @@ def export_table_to_deltalake(
     # Optimize each Delta Lake: z-order, bloom filters, and vacuum.
     celery_logger.info("Optimizing Delta Lakes (z-order, bloom filters, vacuum)...")
     for spec in output_specs:
-        lake_name = spec.partition_by or "flat"
-        uri = f"{output_uri_base}/{lake_name}"
+        uri = f"{output_uri_base}/{spec.name}"
         action = "z_order" if spec.zorder_columns else "compact"
         if optimize_callback is not None:
-            optimize_callback(lake_name, action)
+            optimize_callback(spec.name, action)
         optimize_deltalake(
             uri,
             zorder_columns=spec.zorder_columns or None,
@@ -1117,7 +1119,7 @@ def export_table_to_deltalake(
             max_spill_size=optimize_max_spill_size,
         )
         if optimize_callback is not None:
-            optimize_callback(lake_name, "vacuum")
+            optimize_callback(spec.name, "vacuum")
 
 
 def optimize_deltalake(
@@ -1564,10 +1566,20 @@ def write_deltalake_table(
             )
             return
 
+        # --- Validate unique output names ---
+        seen = set()
+        for spec in resolved_specs:
+            ln = spec.name
+            if ln in seen:
+                raise ValueError(
+                    f"Duplicate output spec name {ln!r}. "
+                    f"Each spec must have a unique name."
+                )
+            seen.add(ln)
+
         # --- Existing Delta Lake detection ---
         for spec in resolved_specs:
-            lake_name = spec.partition_by or "flat"
-            uri = f"{output_uri_base}/{lake_name}"
+            uri = f"{output_uri_base}/{spec.name}"
             try:
                 from deltalake import DeltaTable
 
@@ -1601,7 +1613,7 @@ def write_deltalake_table(
         bytes_per_row = estimate_bytes_per_row(connection_string, source)
 
         for spec in resolved_specs:
-            if spec.n_partitions == "auto":
+            if spec.n_partitions == "auto" or spec.n_partitions is None:
                 effective_target = spec.target_file_size_mb or target_partition_size_mb
                 spec.n_partitions = resolve_n_partitions(
                     "auto",
@@ -1671,8 +1683,16 @@ def write_deltalake_table(
             optimize_max_spill_size=optimize_max_spill_size,
         )
     except Exception as e:
-        _log(f"Export failed: {e}")
-        _set_status(status="failed", total_rows=None, phase="failed", error=str(e))
+        try:
+            _log(f"Export failed: {e}")
+            _set_status(status="failed", total_rows=None, phase="failed", error=str(e))
+        except Exception:
+            celery_logger.warning(
+                "%s (v%d): failed to update Redis status after export error",
+                table_name,
+                version,
+                exc_info=True,
+            )
         raise
 
     _log("Export complete.")

--- a/materializationengine/workflows/deltalake_export.py
+++ b/materializationengine/workflows/deltalake_export.py
@@ -1685,7 +1685,9 @@ def write_deltalake_table(
     except Exception as e:
         try:
             _log(f"Export failed: {e}")
-            _set_status(status="failed", total_rows=row_count, phase="failed", error=str(e))
+            _set_status(
+                status="failed", total_rows=row_count, phase="failed", error=str(e)
+            )
         except Exception:
             celery_logger.warning(
                 "%s (v%d): failed to update Redis status after export error",

--- a/materializationengine/workflows/deltalake_export.py
+++ b/materializationengine/workflows/deltalake_export.py
@@ -67,6 +67,7 @@ class TableSource:
 
 @dataclass
 class DeltaLakeOutputSpec:
+    name: str | None = None
     partition_by: str | None = None
     partition_strategy: Literal["percentile_range", "uniform_range", "hash"] | None = (
         None
@@ -197,6 +198,7 @@ def discover_default_output_specs(
         pk_col = pk_columns[0]
         specs.append(
             DeltaLakeOutputSpec(
+                name=pk_col,
                 partition_by=pk_col,
                 partition_strategy="percentile_range",
                 n_partitions="auto",
@@ -235,6 +237,7 @@ def discover_default_output_specs(
         else:
             specs.append(
                 DeltaLakeOutputSpec(
+                    name=col,
                     partition_by=col,
                     partition_strategy="percentile_range",
                     n_partitions="auto",
@@ -254,6 +257,7 @@ def discover_default_output_specs(
         # exist in the db
         specs.append(
             DeltaLakeOutputSpec(
+                name=f"{col}_morton",
                 partition_by=f"{col}_morton",
                 partition_strategy="uniform_range",
                 n_partitions="auto",

--- a/materializationengine/workflows/deltalake_export.py
+++ b/materializationengine/workflows/deltalake_export.py
@@ -1685,7 +1685,7 @@ def write_deltalake_table(
     except Exception as e:
         try:
             _log(f"Export failed: {e}")
-            _set_status(status="failed", total_rows=None, phase="failed", error=str(e))
+            _set_status(status="failed", total_rows=row_count, phase="failed", error=str(e))
         except Exception:
             celery_logger.warning(
                 "%s (v%d): failed to update Redis status after export error",

--- a/materializationengine/workflows/deltalake_export.py
+++ b/materializationengine/workflows/deltalake_export.py
@@ -1454,213 +1454,205 @@ def write_deltalake_table(
             datastack, version, table_name, job_id=job_id, **kwargs
         )
 
-    # Validate table_name early to prevent SQL injection through all downstream
-    # f-string identifier interpolations in the export pipeline.
-    _validate_identifier(table_name)
-    pcg_table_name = datastack_info["segmentation_source"].split("/")[-1]
-    analysis_database = f"{datastack}__mat{version}"
-
-    sql_uri_config = get_config_param("SQLALCHEMY_DATABASE_URI")
-    connection_string = _build_frozen_db_connection_string(
-        sql_uri_config, datastack, version
-    )
-
-    output_bucket = get_config_param("DELTALAKE_OUTPUT_BUCKET")
-    if not output_bucket:
-        raise ValueError("DELTALAKE_OUTPUT_BUCKET not set in app config")
-    output_uri_base = f"{output_bucket}/{datastack}/v{version}/{table_name}"
-
-    celery_logger.info("Outputting Delta Lakes to: %s", output_uri_base)
-
-    flush_threshold = get_config_param(
-        "DELTALAKE_FLUSH_THRESHOLD_BYTES", 2 * 1024 * 1024 * 1024
-    )
-    target_partition_size_mb = get_config_param(
-        "DELTALAKE_TARGET_PARTITION_SIZE_MB", 256
-    )
-    optimize_max_concurrent_tasks = get_config_param(
-        "DELTALAKE_OPTIMIZE_MAX_CONCURRENT_TASKS", 1
-    )
-    optimize_target_size = get_config_param(
-        "DELTALAKE_OPTIMIZE_TARGET_SIZE_BYTES", None
-    )
-    optimize_max_spill_size = get_config_param(
-        "DELTALAKE_OPTIMIZE_MAX_SPILL_SIZE_BYTES", None
-    )
-
-    # --- Resolve table structure from frozen DB metadata ---
-    engine = db_manager.get_engine(analysis_database)
-
-    # Determine if the table was merged and look up row count.
-    with db_manager.session_scope(analysis_database) as session:
-        metadata_row = (
-            session.query(MaterializedMetadata)
-            .filter(MaterializedMetadata.table_name == table_name)
-            .first()
-        )
-        if metadata_row is None:
-            raise ValueError(
-                f"No MaterializedMetadata entry for table {table_name!r} "
-                f"in {analysis_database}"
-            )
-        row_count = metadata_row.row_count
-
-    # Detect segmentation table presence.
-    seg_table_name = build_segmentation_table_name(table_name, pcg_table_name)
-    has_seg_table = engine.dialect.has_table(engine, seg_table_name)
-    # If merged (no separate seg table), segmentation_table stays None.
-    segmentation_table_name = seg_table_name if has_seg_table else None
-
-    celery_logger.info(
-        "Exporting table %s (v%d) with %d rows; segmentation table: %s",
-        table_name,
-        version,
-        row_count,
-        segmentation_table_name or "none",
-    )
-
-    source = TableSource(
-        annotation_table=table_name,
-        segmentation_table=segmentation_table_name,
-    )
-
-    # --- Resolve output specs ---
-    if output_specs is not None:
-        _log(f"Resolving {len(output_specs)} user-provided output specs...")
-        _set_status(status="exporting", total_rows=row_count, phase="resolving_specs")
-        resolved_specs = [DeltaLakeOutputSpec(**s) for s in output_specs]
-    else:
-        _log("Discovering output specs...")
-        _set_status(status="exporting", total_rows=row_count, phase="discovering_specs")
-        resolved_specs = discover_default_output_specs(source, engine)
-
-    celery_logger.info(
-        "Resolved %d output specs for table %s (v%d)",
-        len(resolved_specs),
-        table_name,
-        version,
-    )
-    for spec in resolved_specs:
-        celery_logger.info(
-            "  - partition_by: %s, strategy: %s",
-            spec.partition_by,
-            spec.partition_strategy,
-        )
-
-    if not resolved_specs:
-        celery_logger.warning(
-            "No output specs for table %s — skipping Delta Lake export", table_name
-        )
-        return
-
-    # --- Existing Delta Lake detection ---
-    for spec in resolved_specs:
-        lake_name = spec.partition_by or "flat"
-        uri = f"{output_uri_base}/{lake_name}"
-        try:
-            from deltalake import DeltaTable
-
-            dt = DeltaTable(uri)
-            # count() reads row count from Delta log add-action metadata
-            # (no file scan).  It may be approximate when per-file stats are
-            # absent, but is fast and sufficient for partial-export detection.
-            existing_rows = dt.count()
-        except Exception:
-            existing_rows = None
-
-        if existing_rows is not None and existing_rows != row_count:
-            raise RuntimeError(
-                f"Delta Lake for table {table_name!r} already exists at "
-                f"{uri} but has {existing_rows} rows (expected {row_count}). "
-                f"This may be the result of a partial export. "
-                f"Delete the existing Delta Lake before re-exporting."
-            )
-
-        if existing_rows is not None:
-            raise RuntimeError(
-                f"Delta Lake for table {table_name!r} already exists at "
-                f"{uri} with {existing_rows} rows (matches expected count). "
-                f"Delete the existing Delta Lake before re-exporting."
-            )
-
-    # --- Estimate bytes per row and resolve partition counts / bounds ---
-    _log(
-        f"Resolved {len(resolved_specs)} output specs. Computing partition boundaries..."
-    )
-    _set_status(status="exporting", total_rows=row_count, phase="computing_boundaries")
-    bytes_per_row = estimate_bytes_per_row(connection_string, source)
-
-    for spec in resolved_specs:
-        if spec.n_partitions == "auto":
-            effective_target = spec.target_file_size_mb or target_partition_size_mb
-            spec.n_partitions = resolve_n_partitions(
-                "auto",
-                row_count,
-                target_file_size_mb=effective_target,
-                bytes_per_row=bytes_per_row,
-            )
-
-    resolve_all_bounds(resolved_specs, connection_string, table_name)
-
-    # --- Stream and write ---
-    celery_logger.info(
-        "Exporting table %s (v%d) to Delta Lake: %d specs, %d rows",
-        table_name,
-        version,
-        len(resolved_specs),
-        row_count,
-    )
-
-    _last_log_time = {"t": 0.0}
-    _LOG_INTERVAL_SECONDS = 30
-
-    def _log_progress(rows_so_far: int, total: int | None) -> None:
-        now = time.monotonic()
-        if now - _last_log_time["t"] < _LOG_INTERVAL_SECONDS:
-            return
-        _last_log_time["t"] = now
-        if total:
-            pct = rows_so_far / total * 100
-            celery_logger.info(
-                "Delta Lake export progress for %s (v%d): %d / %d rows (%.1f%%)",
-                table_name,
-                version,
-                rows_so_far,
-                total,
-                pct,
-            )
-        else:
-            celery_logger.info(
-                "Delta Lake export progress for %s (v%d): %d rows",
-                table_name,
-                version,
-                rows_so_far,
-            )
-
-    redis_callback = make_redis_progress_callback(
-        datastack, version, table_name, job_id=job_id
-    )
-
-    def _progress(rows_so_far: int, total: int | None) -> None:
-        _log_progress(rows_so_far, total)
-        redis_callback(rows_so_far, total)
-
-    _log(f"Streaming {row_count:,} rows to Delta Lake...")
-    _set_status(status="exporting", total_rows=row_count, phase="streaming")
-
-    def _optimize_callback(spec_name: str, action: str) -> None:
-        _set_status(
-            status="exporting",
-            total_rows=row_count,
-            rows_processed=row_count,
-            phase="optimizing",
-        )
-        if action == "vacuum":
-            _log(f"Vacuuming Delta Lake '{spec_name}'...")
-        else:
-            _log(f"Optimizing Delta Lake '{spec_name}' ({action})...")
+    def _phase(phase: str, message: str, **status_kwargs) -> None:
+        """Log to celery + Redis log list + Redis status in one call."""
+        celery_logger.info("%s (v%d): %s", table_name, version, message)
+        _log(message)
+        _set_status(status="exporting", phase=phase, **status_kwargs)
 
     try:
+        # Validate table_name early to prevent SQL injection through all downstream
+        # f-string identifier interpolations in the export pipeline.
+        _validate_identifier(table_name)
+        pcg_table_name = datastack_info["segmentation_source"].split("/")[-1]
+        analysis_database = f"{datastack}__mat{version}"
+
+        sql_uri_config = get_config_param("SQLALCHEMY_DATABASE_URI")
+        connection_string = _build_frozen_db_connection_string(
+            sql_uri_config, datastack, version
+        )
+
+        output_bucket = get_config_param("DELTALAKE_OUTPUT_BUCKET")
+        if not output_bucket:
+            raise ValueError("DELTALAKE_OUTPUT_BUCKET not set in app config")
+        output_uri_base = f"{output_bucket}/{datastack}/v{version}/{table_name}"
+
+        celery_logger.info("Outputting Delta Lakes to: %s", output_uri_base)
+
+        flush_threshold = get_config_param(
+            "DELTALAKE_FLUSH_THRESHOLD_BYTES", 2 * 1024 * 1024 * 1024
+        )
+        target_partition_size_mb = get_config_param(
+            "DELTALAKE_TARGET_PARTITION_SIZE_MB", 256
+        )
+        optimize_max_concurrent_tasks = get_config_param(
+            "DELTALAKE_OPTIMIZE_MAX_CONCURRENT_TASKS", 1
+        )
+        optimize_target_size = get_config_param(
+            "DELTALAKE_OPTIMIZE_TARGET_SIZE_BYTES", None
+        )
+        optimize_max_spill_size = get_config_param(
+            "DELTALAKE_OPTIMIZE_MAX_SPILL_SIZE_BYTES", None
+        )
+
+        # --- Resolve table structure from frozen DB metadata ---
+        engine = db_manager.get_engine(analysis_database)
+
+        # Determine if the table was merged and look up row count.
+        with db_manager.session_scope(analysis_database) as session:
+            metadata_row = (
+                session.query(MaterializedMetadata)
+                .filter(MaterializedMetadata.table_name == table_name)
+                .first()
+            )
+            if metadata_row is None:
+                raise ValueError(
+                    f"No MaterializedMetadata entry for table {table_name!r} "
+                    f"in {analysis_database}"
+                )
+            row_count = metadata_row.row_count
+
+        # Detect segmentation table presence.
+        seg_table_name = build_segmentation_table_name(table_name, pcg_table_name)
+        has_seg_table = engine.dialect.has_table(engine, seg_table_name)
+        segmentation_table_name = seg_table_name if has_seg_table else None
+
+        celery_logger.info(
+            "Table %s (v%d): %d rows, segmentation=%s",
+            table_name,
+            version,
+            row_count,
+            segmentation_table_name or "none",
+        )
+
+        source = TableSource(
+            annotation_table=table_name,
+            segmentation_table=segmentation_table_name,
+        )
+
+        # --- Resolve output specs ---
+        if output_specs is not None:
+            _phase(
+                "resolving_specs",
+                f"Resolving {len(output_specs)} user-provided output specs...",
+                total_rows=row_count,
+            )
+            resolved_specs = [DeltaLakeOutputSpec(**s) for s in output_specs]
+        else:
+            _phase(
+                "discovering_specs",
+                "Discovering output specs...",
+                total_rows=row_count,
+            )
+            resolved_specs = discover_default_output_specs(source, engine)
+
+        for spec in resolved_specs:
+            celery_logger.info(
+                "  - partition_by: %s, strategy: %s",
+                spec.partition_by,
+                spec.partition_strategy,
+            )
+
+        if not resolved_specs:
+            celery_logger.warning(
+                "No output specs for table %s — skipping Delta Lake export",
+                table_name,
+            )
+            return
+
+        # --- Existing Delta Lake detection ---
+        for spec in resolved_specs:
+            lake_name = spec.partition_by or "flat"
+            uri = f"{output_uri_base}/{lake_name}"
+            try:
+                from deltalake import DeltaTable
+
+                dt = DeltaTable(uri)
+                existing_rows = dt.count()
+            except Exception:
+                existing_rows = None
+
+            if existing_rows is not None and existing_rows != row_count:
+                raise RuntimeError(
+                    f"Delta Lake for table {table_name!r} already exists at "
+                    f"{uri} but has {existing_rows} rows (expected {row_count}). "
+                    f"This may be the result of a partial export. "
+                    f"Delete the existing Delta Lake before re-exporting."
+                )
+
+            if existing_rows is not None:
+                raise RuntimeError(
+                    f"Delta Lake for table {table_name!r} already exists at "
+                    f"{uri} with {existing_rows} rows (matches expected count). "
+                    f"Delete the existing Delta Lake before re-exporting."
+                )
+
+        # --- Estimate bytes per row and resolve partition counts / bounds ---
+        _phase(
+            "computing_boundaries",
+            f"Resolved {len(resolved_specs)} output specs. "
+            "Computing partition boundaries...",
+            total_rows=row_count,
+        )
+        bytes_per_row = estimate_bytes_per_row(connection_string, source)
+
+        for spec in resolved_specs:
+            if spec.n_partitions == "auto":
+                effective_target = spec.target_file_size_mb or target_partition_size_mb
+                spec.n_partitions = resolve_n_partitions(
+                    "auto",
+                    row_count,
+                    target_file_size_mb=effective_target,
+                    bytes_per_row=bytes_per_row,
+                )
+
+        resolve_all_bounds(resolved_specs, connection_string, table_name)
+
+        # --- Stream and write ---
+        _last_log_time = {"t": 0.0}
+
+        def _log_progress(rows_so_far: int, total: int | None) -> None:
+            now = time.monotonic()
+            if now - _last_log_time["t"] < 30:
+                return
+            _last_log_time["t"] = now
+            pct = f" ({rows_so_far / total * 100:.1f}%)" if total else ""
+            celery_logger.info(
+                "%s (v%d): %d rows exported%s",
+                table_name,
+                version,
+                rows_so_far,
+                pct,
+            )
+
+        redis_callback = make_redis_progress_callback(
+            datastack, version, table_name, job_id=job_id
+        )
+
+        def _progress(rows_so_far: int, total: int | None) -> None:
+            _log_progress(rows_so_far, total)
+            redis_callback(rows_so_far, total)
+
+        _phase(
+            "streaming",
+            f"Streaming {row_count:,} rows to Delta Lake...",
+            total_rows=row_count,
+        )
+
+        def _optimize_callback(spec_name: str, action: str) -> None:
+            msg = (
+                f"Vacuuming Delta Lake '{spec_name}'..."
+                if action == "vacuum"
+                else f"Optimizing Delta Lake '{spec_name}' ({action})..."
+            )
+            _log(msg)
+            _set_status(
+                status="exporting",
+                total_rows=row_count,
+                rows_processed=row_count,
+                phase="optimizing",
+            )
+
         export_table_to_deltalake(
             connection_string=connection_string,
             source=source,
@@ -1676,7 +1668,7 @@ def write_deltalake_table(
         )
     except Exception as e:
         _log(f"Export failed: {e}")
-        _set_status(status="failed", total_rows=row_count, phase="failed", error=str(e))
+        _set_status(status="failed", total_rows=None, phase="failed", error=str(e))
         raise
 
     _log("Export complete.")
@@ -1686,7 +1678,4 @@ def write_deltalake_table(
         rows_processed=row_count,
         phase="complete",
     )
-
-    celery_logger.info(
-        "Delta Lake export complete for table %s (v%d)", table_name, version
-    )
+    celery_logger.info("%s (v%d): export complete", table_name, version)

--- a/materializationengine/workflows/deltalake_export.py
+++ b/materializationengine/workflows/deltalake_export.py
@@ -1243,14 +1243,24 @@ def make_tqdm_progress_callback(
 _DELTALAKE_PROGRESS_TTL = 86400  # 24 hours
 
 
-def deltalake_export_redis_key(datastack: str, version: int, table_name: str) -> str:
+def deltalake_export_redis_key(
+    datastack: str, version: int, table_name: str, job_id: str | None = None
+) -> str:
     """Return the Redis key used to track Delta Lake export progress."""
-    return f"deltalake_export:{datastack}:v{version}:{table_name}"
+    base = f"deltalake_export:{datastack}:v{version}:{table_name}"
+    if job_id:
+        return f"{base}:{job_id}"
+    return base
 
 
-def _deltalake_log_redis_key(datastack: str, version: int, table_name: str) -> str:
+def _deltalake_log_redis_key(
+    datastack: str, version: int, table_name: str, job_id: str | None = None
+) -> str:
     """Return the Redis key for the capped log list."""
-    return f"deltalake_log:{datastack}:v{version}:{table_name}"
+    base = f"deltalake_log:{datastack}:v{version}:{table_name}"
+    if job_id:
+        return f"{base}:{job_id}"
+    return base
 
 
 _DELTALAKE_LOG_MAX_ENTRIES = 100
@@ -1261,10 +1271,11 @@ def append_deltalake_log(
     version: int,
     table_name: str,
     message: str,
+    job_id: str | None = None,
 ) -> None:
     """Append a timestamped log entry to the capped Redis log list."""
     client = _get_redis_client()
-    key = _deltalake_log_redis_key(datastack, version, table_name)
+    key = _deltalake_log_redis_key(datastack, version, table_name, job_id=job_id)
     timestamped = f"{datetime.now(timezone.utc).strftime('%H:%M:%S')} {message}"
     client.rpush(key, timestamped)
     client.ltrim(key, -_DELTALAKE_LOG_MAX_ENTRIES, -1)
@@ -1289,6 +1300,7 @@ def make_redis_progress_callback(
     datastack: str,
     version: int,
     table_name: str,
+    job_id: str | None = None,
 ) -> Callable[[int, int | None], None]:
     """Create a Redis-backed progress callback for :func:`export_table_to_deltalake`.
 
@@ -1296,7 +1308,7 @@ def make_redis_progress_callback(
     can poll export progress.  The key expires after 24 hours.
     """
     client = _get_redis_client()
-    key = deltalake_export_redis_key(datastack, version, table_name)
+    key = deltalake_export_redis_key(datastack, version, table_name, job_id=job_id)
 
     def _callback(rows_so_far: int, total: int | None) -> None:
         pct = (rows_so_far / total * 100) if total else None
@@ -1323,10 +1335,11 @@ def set_deltalake_export_status(
     rows_processed: int | None = None,
     phase: str | None = None,
     error: str | None = None,
+    job_id: str | None = None,
 ) -> None:
     """Write a terminal status (``complete``, ``failed``, etc.) to Redis."""
     client = _get_redis_client()
-    key = deltalake_export_redis_key(datastack, version, table_name)
+    key = deltalake_export_redis_key(datastack, version, table_name, job_id=job_id)
     pct = None
     if rows_processed is not None and total_rows:
         pct = round(rows_processed / total_rows * 100, 2)
@@ -1346,6 +1359,7 @@ def get_deltalake_export_progress(
     datastack: str,
     version: int,
     table_name: str,
+    job_id: str | None = None,
 ) -> dict | None:
     """Read the current export progress from Redis.
 
@@ -1353,13 +1367,13 @@ def get_deltalake_export_progress(
     if no export is tracked.
     """
     client = _get_redis_client()
-    key = deltalake_export_redis_key(datastack, version, table_name)
+    key = deltalake_export_redis_key(datastack, version, table_name, job_id=job_id)
     raw = client.get(key)
     if raw is None:
         return None
     progress = json.loads(raw)
     # Attach log entries from the capped Redis list.
-    log_key = _deltalake_log_redis_key(datastack, version, table_name)
+    log_key = _deltalake_log_redis_key(datastack, version, table_name, job_id=job_id)
     log_entries = client.lrange(log_key, 0, -1)
     progress["log_entries"] = [
         entry.decode() if isinstance(entry, bytes) else entry
@@ -1396,6 +1410,7 @@ def write_deltalake_table(
     version: int,
     table_name: str,
     output_specs: list[dict] | None = None,
+    job_id: str | None = None,
 ) -> None:
     """Orchestrate a full Delta Lake export for one table.
 
@@ -1416,6 +1431,10 @@ def write_deltalake_table(
     output_specs
         Optional list of output spec dicts.  If ``None``, defaults are
         derived from table indexes.
+    job_id
+        Unique identifier for this export job.  Used to disambiguate
+        Redis progress keys when the same table/version is exported
+        multiple times.
     """
     from dynamicannotationdb.key_utils import build_segmentation_table_name
     from sqlalchemy import create_engine
@@ -1425,6 +1444,16 @@ def write_deltalake_table(
     from materializationengine.utils import get_config_param
 
     datastack = datastack_info["datastack"]
+
+    # --- Job-scoped helpers that bind job_id into Redis key calls ---
+    def _log(message: str) -> None:
+        append_deltalake_log(datastack, version, table_name, message, job_id=job_id)
+
+    def _set_status(**kwargs) -> None:
+        set_deltalake_export_status(
+            datastack, version, table_name, job_id=job_id, **kwargs
+        )
+
     # Validate table_name early to prevent SQL injection through all downstream
     # f-string identifier interpolations in the export pipeline.
     _validate_identifier(table_name)
@@ -1497,36 +1526,12 @@ def write_deltalake_table(
 
     # --- Resolve output specs ---
     if output_specs is not None:
-        append_deltalake_log(
-            datastack,
-            version,
-            table_name,
-            f"Resolving {len(output_specs)} user-provided output specs...",
-        )
-        set_deltalake_export_status(
-            datastack,
-            version,
-            table_name,
-            "exporting",
-            total_rows=row_count,
-            phase="resolving_specs",
-        )
+        _log(f"Resolving {len(output_specs)} user-provided output specs...")
+        _set_status(status="exporting", total_rows=row_count, phase="resolving_specs")
         resolved_specs = [DeltaLakeOutputSpec(**s) for s in output_specs]
     else:
-        append_deltalake_log(
-            datastack,
-            version,
-            table_name,
-            "Discovering output specs...",
-        )
-        set_deltalake_export_status(
-            datastack,
-            version,
-            table_name,
-            "exporting",
-            total_rows=row_count,
-            phase="discovering_specs",
-        )
+        _log("Discovering output specs...")
+        _set_status(status="exporting", total_rows=row_count, phase="discovering_specs")
         resolved_specs = discover_default_output_specs(source, engine)
 
     celery_logger.info(
@@ -1579,20 +1584,10 @@ def write_deltalake_table(
             )
 
     # --- Estimate bytes per row and resolve partition counts / bounds ---
-    append_deltalake_log(
-        datastack,
-        version,
-        table_name,
-        f"Resolved {len(resolved_specs)} output specs. Computing partition boundaries...",
+    _log(
+        f"Resolved {len(resolved_specs)} output specs. Computing partition boundaries..."
     )
-    set_deltalake_export_status(
-        datastack,
-        version,
-        table_name,
-        "exporting",
-        total_rows=row_count,
-        phase="computing_boundaries",
-    )
+    _set_status(status="exporting", total_rows=row_count, phase="computing_boundaries")
     bytes_per_row = estimate_bytes_per_row(connection_string, source)
 
     for spec in resolved_specs:
@@ -1642,51 +1637,28 @@ def write_deltalake_table(
                 rows_so_far,
             )
 
-    redis_callback = make_redis_progress_callback(datastack, version, table_name)
+    redis_callback = make_redis_progress_callback(
+        datastack, version, table_name, job_id=job_id
+    )
 
     def _progress(rows_so_far: int, total: int | None) -> None:
         _log_progress(rows_so_far, total)
         redis_callback(rows_so_far, total)
 
-    append_deltalake_log(
-        datastack,
-        version,
-        table_name,
-        f"Streaming {row_count:,} rows to Delta Lake...",
-    )
-    set_deltalake_export_status(
-        datastack,
-        version,
-        table_name,
-        "exporting",
-        total_rows=row_count,
-        phase="streaming",
-    )
+    _log(f"Streaming {row_count:,} rows to Delta Lake...")
+    _set_status(status="exporting", total_rows=row_count, phase="streaming")
 
     def _optimize_callback(spec_name: str, action: str) -> None:
-        set_deltalake_export_status(
-            datastack,
-            version,
-            table_name,
-            "exporting",
+        _set_status(
+            status="exporting",
             total_rows=row_count,
             rows_processed=row_count,
             phase="optimizing",
         )
         if action == "vacuum":
-            append_deltalake_log(
-                datastack,
-                version,
-                table_name,
-                f"Vacuuming Delta Lake '{spec_name}'...",
-            )
+            _log(f"Vacuuming Delta Lake '{spec_name}'...")
         else:
-            append_deltalake_log(
-                datastack,
-                version,
-                table_name,
-                f"Optimizing Delta Lake '{spec_name}' ({action})...",
-            )
+            _log(f"Optimizing Delta Lake '{spec_name}' ({action})...")
 
     try:
         export_table_to_deltalake(
@@ -1703,24 +1675,13 @@ def write_deltalake_table(
             optimize_max_spill_size=optimize_max_spill_size,
         )
     except Exception as e:
-        append_deltalake_log(datastack, version, table_name, f"Export failed: {e}")
-        set_deltalake_export_status(
-            datastack,
-            version,
-            table_name,
-            "failed",
-            total_rows=row_count,
-            phase="failed",
-            error=str(e),
-        )
+        _log(f"Export failed: {e}")
+        _set_status(status="failed", total_rows=row_count, phase="failed", error=str(e))
         raise
 
-    append_deltalake_log(datastack, version, table_name, "Export complete.")
-    set_deltalake_export_status(
-        datastack,
-        version,
-        table_name,
-        "complete",
+    _log("Export complete.")
+    _set_status(
+        status="complete",
         total_rows=row_count,
         rows_processed=row_count,
         phase="complete",

--- a/materializationengine/workflows/deltalake_export.py
+++ b/materializationengine/workflows/deltalake_export.py
@@ -77,6 +77,7 @@ class DeltaLakeOutputSpec:
     source_geometry_column: str | None = None
     source_table: str | None = None
     bounds: list | None = None
+    target_file_size_mb: int | None = None
 
 
 _IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_$]*$")
@@ -1088,6 +1089,7 @@ def export_table_to_deltalake(
         )
 
     # Optimize each Delta Lake: z-order, bloom filters, and vacuum.
+    celery_logger.info("Optimizing Delta Lakes (z-order, bloom filters, vacuum)...")
     for spec in output_specs:
         lake_name = spec.partition_by or "flat"
         uri = f"{output_uri_base}/{lake_name}"
@@ -1233,6 +1235,29 @@ def deltalake_export_redis_key(datastack: str, version: int, table_name: str) ->
     return f"deltalake_export:{datastack}:v{version}:{table_name}"
 
 
+def _deltalake_log_redis_key(datastack: str, version: int, table_name: str) -> str:
+    """Return the Redis key for the capped log list."""
+    return f"deltalake_log:{datastack}:v{version}:{table_name}"
+
+
+_DELTALAKE_LOG_MAX_ENTRIES = 100
+
+
+def append_deltalake_log(
+    datastack: str,
+    version: int,
+    table_name: str,
+    message: str,
+) -> None:
+    """Append a timestamped log entry to the capped Redis log list."""
+    client = _get_redis_client()
+    key = _deltalake_log_redis_key(datastack, version, table_name)
+    timestamped = f"{datetime.now(timezone.utc).strftime('%H:%M:%S')} {message}"
+    client.rpush(key, timestamped)
+    client.ltrim(key, -_DELTALAKE_LOG_MAX_ENTRIES, -1)
+    client.expire(key, _DELTALAKE_PROGRESS_TTL)
+
+
 def _get_redis_client():
     """Lazy-create a Redis client for deltalake export progress."""
     import redis
@@ -1264,9 +1289,11 @@ def make_redis_progress_callback(
         pct = (rows_so_far / total * 100) if total else None
         payload = {
             "status": "exporting",
+            "phase": "streaming",
             "rows_processed": rows_so_far,
             "total_rows": total,
             "percent_complete": round(pct, 2) if pct is not None else None,
+            "error": None,
             "last_updated": datetime.now(timezone.utc).isoformat(),
         }
         client.set(key, json.dumps(payload), ex=_DELTALAKE_PROGRESS_TTL)
@@ -1281,6 +1308,8 @@ def set_deltalake_export_status(
     status: str,
     total_rows: int | None = None,
     rows_processed: int | None = None,
+    phase: str | None = None,
+    error: str | None = None,
 ) -> None:
     """Write a terminal status (``complete``, ``failed``, etc.) to Redis."""
     client = _get_redis_client()
@@ -1290,9 +1319,11 @@ def set_deltalake_export_status(
         pct = round(rows_processed / total_rows * 100, 2)
     payload = {
         "status": status,
+        "phase": phase,
         "rows_processed": rows_processed,
         "total_rows": total_rows,
         "percent_complete": pct,
+        "error": error,
         "last_updated": datetime.now(timezone.utc).isoformat(),
     }
     client.set(key, json.dumps(payload), ex=_DELTALAKE_PROGRESS_TTL)
@@ -1305,14 +1336,23 @@ def get_deltalake_export_progress(
 ) -> dict | None:
     """Read the current export progress from Redis.
 
-    Returns the progress dict, or ``None`` if no export is tracked.
+    Returns the progress dict (including ``log_entries``), or ``None``
+    if no export is tracked.
     """
     client = _get_redis_client()
     key = deltalake_export_redis_key(datastack, version, table_name)
     raw = client.get(key)
     if raw is None:
         return None
-    return json.loads(raw)
+    progress = json.loads(raw)
+    # Attach log entries from the capped Redis list.
+    log_key = _deltalake_log_redis_key(datastack, version, table_name)
+    log_entries = client.lrange(log_key, 0, -1)
+    progress["log_entries"] = [
+        entry.decode() if isinstance(entry, bytes) else entry
+        for entry in (log_entries or [])
+    ]
+    return progress
 
 
 def _build_frozen_db_connection_string(
@@ -1443,6 +1483,15 @@ def write_deltalake_table(
     )
 
     # --- Resolve output specs ---
+    append_deltalake_log(datastack, version, table_name, "Discovering output specs...")
+    set_deltalake_export_status(
+        datastack,
+        version,
+        table_name,
+        "exporting",
+        total_rows=row_count,
+        phase="discovering_specs",
+    )
     if output_specs is not None:
         resolved_specs = [DeltaLakeOutputSpec(**s) for s in output_specs]
     else:
@@ -1498,14 +1547,29 @@ def write_deltalake_table(
             )
 
     # --- Estimate bytes per row and resolve partition counts / bounds ---
+    append_deltalake_log(
+        datastack,
+        version,
+        table_name,
+        f"Resolved {len(resolved_specs)} output specs. Computing partition boundaries...",
+    )
+    set_deltalake_export_status(
+        datastack,
+        version,
+        table_name,
+        "exporting",
+        total_rows=row_count,
+        phase="computing_boundaries",
+    )
     bytes_per_row = estimate_bytes_per_row(connection_string, source)
 
     for spec in resolved_specs:
         if spec.n_partitions == "auto":
+            effective_target = spec.target_file_size_mb or target_partition_size_mb
             spec.n_partitions = resolve_n_partitions(
                 "auto",
                 row_count,
-                target_file_size_mb=target_partition_size_mb,
+                target_file_size_mb=effective_target,
                 bytes_per_row=bytes_per_row,
             )
 
@@ -1552,8 +1616,19 @@ def write_deltalake_table(
         _log_progress(rows_so_far, total)
         redis_callback(rows_so_far, total)
 
+    append_deltalake_log(
+        datastack,
+        version,
+        table_name,
+        f"Streaming {row_count:,} rows to Delta Lake...",
+    )
     set_deltalake_export_status(
-        datastack, version, table_name, "exporting", total_rows=row_count
+        datastack,
+        version,
+        table_name,
+        "exporting",
+        total_rows=row_count,
+        phase="streaming",
     )
 
     try:
@@ -1569,16 +1644,20 @@ def write_deltalake_table(
             optimize_target_size=optimize_target_size,
             optimize_max_spill_size=optimize_max_spill_size,
         )
-    except Exception:
+    except Exception as e:
+        append_deltalake_log(datastack, version, table_name, f"Export failed: {e}")
         set_deltalake_export_status(
             datastack,
             version,
             table_name,
             "failed",
             total_rows=row_count,
+            phase="failed",
+            error=str(e),
         )
         raise
 
+    append_deltalake_log(datastack, version, table_name, "Export complete.")
     set_deltalake_export_status(
         datastack,
         version,
@@ -1586,6 +1665,7 @@ def write_deltalake_table(
         "complete",
         total_rows=row_count,
         rows_processed=row_count,
+        phase="complete",
     )
 
     celery_logger.info(

--- a/materializationengine/workflows/deltalake_export.py
+++ b/materializationengine/workflows/deltalake_export.py
@@ -1010,6 +1010,7 @@ def export_table_to_deltalake(
     flush_threshold_bytes: int = 2 * 1024 * 1024 * 1024,
     total_rows: int | None = None,
     progress_callback: Callable[[int, int | None], None] | None = None,
+    optimize_callback: Callable[[str, str], None] | None = None,
     row_limit: int | None = None,
     optimize_max_concurrent_tasks: int = 1,
     optimize_target_size: int | None = None,
@@ -1034,6 +1035,11 @@ def export_table_to_deltalake(
         If provided, called after each Arrow batch with
         ``(rows_processed_so_far, total_rows)``.  *total_rows* may be
         ``None`` if the caller doesn't know the table size.
+    optimize_callback
+        If provided, called before each spec's optimize step with
+        ``(spec_name, action)`` where *action* is one of
+        ``"z_order"``, ``"compact"``, or ``"vacuum"``.  Used to update
+        external progress tracking (e.g. Redis phase/log).
     total_rows
         Total expected row count (e.g. from ``MaterializedMetadata``).
         Passed through to *progress_callback*.
@@ -1094,6 +1100,9 @@ def export_table_to_deltalake(
     for spec in output_specs:
         lake_name = spec.partition_by or "flat"
         uri = f"{output_uri_base}/{lake_name}"
+        action = "z_order" if spec.zorder_columns else "compact"
+        if optimize_callback is not None:
+            optimize_callback(lake_name, action)
         optimize_deltalake(
             uri,
             zorder_columns=spec.zorder_columns or None,
@@ -1103,6 +1112,8 @@ def export_table_to_deltalake(
             target_size=optimize_target_size,
             max_spill_size=optimize_max_spill_size,
         )
+        if optimize_callback is not None:
+            optimize_callback(lake_name, "vacuum")
 
 
 def optimize_deltalake(
@@ -1485,18 +1496,37 @@ def write_deltalake_table(
     )
 
     # --- Resolve output specs ---
-    append_deltalake_log(datastack, version, table_name, "Discovering output specs...")
-    set_deltalake_export_status(
-        datastack,
-        version,
-        table_name,
-        "exporting",
-        total_rows=row_count,
-        phase="discovering_specs",
-    )
     if output_specs is not None:
+        append_deltalake_log(
+            datastack,
+            version,
+            table_name,
+            f"Resolving {len(output_specs)} user-provided output specs...",
+        )
+        set_deltalake_export_status(
+            datastack,
+            version,
+            table_name,
+            "exporting",
+            total_rows=row_count,
+            phase="resolving_specs",
+        )
         resolved_specs = [DeltaLakeOutputSpec(**s) for s in output_specs]
     else:
+        append_deltalake_log(
+            datastack,
+            version,
+            table_name,
+            "Discovering output specs...",
+        )
+        set_deltalake_export_status(
+            datastack,
+            version,
+            table_name,
+            "exporting",
+            total_rows=row_count,
+            phase="discovering_specs",
+        )
         resolved_specs = discover_default_output_specs(source, engine)
 
     celery_logger.info(
@@ -1633,6 +1663,31 @@ def write_deltalake_table(
         phase="streaming",
     )
 
+    def _optimize_callback(spec_name: str, action: str) -> None:
+        set_deltalake_export_status(
+            datastack,
+            version,
+            table_name,
+            "exporting",
+            total_rows=row_count,
+            rows_processed=row_count,
+            phase="optimizing",
+        )
+        if action == "vacuum":
+            append_deltalake_log(
+                datastack,
+                version,
+                table_name,
+                f"Vacuuming Delta Lake '{spec_name}'...",
+            )
+        else:
+            append_deltalake_log(
+                datastack,
+                version,
+                table_name,
+                f"Optimizing Delta Lake '{spec_name}' ({action})...",
+            )
+
     try:
         export_table_to_deltalake(
             connection_string=connection_string,
@@ -1642,6 +1697,7 @@ def write_deltalake_table(
             flush_threshold_bytes=flush_threshold,
             total_rows=row_count,
             progress_callback=_progress,
+            optimize_callback=_optimize_callback,
             optimize_max_concurrent_tasks=optimize_max_concurrent_tasks,
             optimize_target_size=optimize_target_size,
             optimize_max_spill_size=optimize_max_spill_size,

--- a/materializationengine/workflows/deltalake_export.py
+++ b/materializationengine/workflows/deltalake_export.py
@@ -74,6 +74,7 @@ class DeltaLakeOutputSpec:
     n_partitions: int | Literal["auto"] = "auto"
     zorder_columns: list[str] = field(default_factory=list)
     bloom_filter_columns: list[str] = field(default_factory=list)
+    bloom_filter_fpp: float | None = None
     source_geometry_column: str | None = None
     source_table: str | None = None
     bounds: list | None = None
@@ -1097,6 +1098,7 @@ def export_table_to_deltalake(
             uri,
             zorder_columns=spec.zorder_columns or None,
             bloom_filter_columns=spec.bloom_filter_columns or None,
+            fpp=spec.bloom_filter_fpp or 0.001,
             max_concurrent_tasks=optimize_max_concurrent_tasks,
             target_size=optimize_target_size,
             max_spill_size=optimize_max_spill_size,

--- a/static/js/deltalakeRunningExports.js
+++ b/static/js/deltalakeRunningExports.js
@@ -41,12 +41,12 @@ document.addEventListener("alpine:init", () => {
         const resp = await fetch(url);
         if (!resp.ok) {
           if (resp.status === 404) {
-            this.progress[key] = { status: "pending", phase: "pending" };
+            this.progress = { ...this.progress, [key]: { status: "pending", phase: "pending" } };
           }
           return;
         }
         const data = await resp.json();
-        this.progress[key] = data;
+        this.progress = { ...this.progress, [key]: data };
       } catch (e) {
         console.error("[DeltaLake] Polling error:", e);
       }

--- a/static/js/deltalakeRunningExports.js
+++ b/static/js/deltalakeRunningExports.js
@@ -1,51 +1,63 @@
 document.addEventListener("alpine:init", () => {
   Alpine.data("deltalakeRunningExports", () => ({
-    exportKey: null,
-    progress: {},
+    exports: [],
+    progress: {},  // keyed by "datastack/version/tableName"
     poller: null,
-    userScrolled: false,
 
     init() {
       const store = Alpine.store("dlWizard");
-      this.exportKey = store.state.exportKey;
+      this.exports = store.state.exports || [];
 
-      if (this.exportKey) {
-        this.pollProgress();
-        this.poller = setInterval(() => this.pollProgress(), 5000);
+      if (this.exports.length > 0) {
+        this.pollAll();
+        this.poller = setInterval(() => this.pollAll(), 5000);
       }
     },
 
-    async pollProgress() {
-      if (!this.exportKey) return;
-      const { datastack, version, tableName } = this.exportKey;
-      const url = `/materialize/api/v3/materialize/run/write_deltalake/datastack/${datastack}/version/${version}/table_name/${tableName}/`;
+    exportId(exp) {
+      return `${exp.datastack}/${exp.version}/${exp.tableName}`;
+    },
+
+    getProgress(exp) {
+      return this.progress[this.exportId(exp)] || {};
+    },
+
+    async pollAll() {
+      await Promise.all(this.exports.map((exp) => this.pollOne(exp)));
+      // Stop polling if all are terminal
+      const allDone = this.exports.every((exp) => {
+        const p = this.getProgress(exp);
+        return p.status === "complete" || p.status === "failed";
+      });
+      if (allDone) this.stopPolling();
+    },
+
+    async pollOne(exp) {
+      const { datastack, version, tableName } = exp;
+      const url = `/materialize/api/v2/materialize/run/write_deltalake/datastack/${datastack}/version/${version}/table_name/${tableName}/`;
+      const key = this.exportId(exp);
 
       try {
         const resp = await fetch(url);
         if (!resp.ok) {
           if (resp.status === 404) {
-            this.progress = { status: "pending", phase: "pending" };
+            this.progress[key] = { status: "pending", phase: "pending" };
           }
           return;
         }
         const data = await resp.json();
-        this.progress = data;
-
-        // Auto-scroll log panel
-        this.$nextTick(() => {
-          const panel = this.$refs.logPanel;
-          if (panel && !this.userScrolled) {
-            panel.scrollTop = panel.scrollHeight;
-          }
-        });
-
-        // Stop polling on terminal status
-        if (data.status === "complete" || data.status === "failed") {
-          this.stopPolling();
-        }
+        this.progress[key] = data;
       } catch (e) {
         console.error("[DeltaLake] Polling error:", e);
       }
+    },
+
+    removeExport(idx) {
+      this.exports.splice(idx, 1);
+      // Persist removal
+      const store = Alpine.store("dlWizard");
+      store.state.exports = this.exports;
+      store.saveState();
     },
 
     stopPolling() {
@@ -59,20 +71,4 @@ document.addEventListener("alpine:init", () => {
       this.stopPolling();
     },
   }));
-
-  // Handle log panel scroll detection
-  document.addEventListener("scroll", (e) => {
-    if (e.target.classList && e.target.classList.contains("log-panel")) {
-      const panel = e.target;
-      const atBottom =
-        panel.scrollHeight - panel.scrollTop - panel.clientHeight < 20;
-      // Find the Alpine component — best-effort
-      const component = Alpine.$data(
-        document.querySelector("[x-data='deltalakeRunningExports']")
-      );
-      if (component) {
-        component.userScrolled = !atBottom;
-      }
-    }
-  }, true);
 });

--- a/static/js/deltalakeRunningExports.js
+++ b/static/js/deltalakeRunningExports.js
@@ -15,7 +15,7 @@ document.addEventListener("alpine:init", () => {
     },
 
     exportId(exp) {
-      return `${exp.datastack}/${exp.version}/${exp.tableName}`;
+      return `${exp.datastack}/${exp.version}/${exp.tableName}/${exp.jobId || "default"}`;
     },
 
     getProgress(exp) {
@@ -33,8 +33,11 @@ document.addEventListener("alpine:init", () => {
     },
 
     async pollOne(exp) {
-      const { datastack, version, tableName } = exp;
-      const url = `/materialize/api/v2/materialize/run/write_deltalake/datastack/${datastack}/version/${version}/table_name/${tableName}/`;
+      const { datastack, version, tableName, jobId } = exp;
+      let url = `/materialize/api/v2/materialize/run/write_deltalake/datastack/${datastack}/version/${version}/table_name/${tableName}/`;
+      if (jobId) {
+        url += `?job_id=${encodeURIComponent(jobId)}`;
+      }
       const key = this.exportId(exp);
 
       try {

--- a/static/js/deltalakeRunningExports.js
+++ b/static/js/deltalakeRunningExports.js
@@ -1,0 +1,78 @@
+document.addEventListener("alpine:init", () => {
+  Alpine.data("deltalakeRunningExports", () => ({
+    exportKey: null,
+    progress: {},
+    poller: null,
+    userScrolled: false,
+
+    init() {
+      const store = Alpine.store("dlWizard");
+      this.exportKey = store.state.exportKey;
+
+      if (this.exportKey) {
+        this.pollProgress();
+        this.poller = setInterval(() => this.pollProgress(), 5000);
+      }
+    },
+
+    async pollProgress() {
+      if (!this.exportKey) return;
+      const { datastack, version, tableName } = this.exportKey;
+      const url = `/materialize/api/v3/materialize/run/write_deltalake/datastack/${datastack}/version/${version}/table_name/${tableName}/`;
+
+      try {
+        const resp = await fetch(url);
+        if (!resp.ok) {
+          if (resp.status === 404) {
+            this.progress = { status: "pending", phase: "pending" };
+          }
+          return;
+        }
+        const data = await resp.json();
+        this.progress = data;
+
+        // Auto-scroll log panel
+        this.$nextTick(() => {
+          const panel = this.$refs.logPanel;
+          if (panel && !this.userScrolled) {
+            panel.scrollTop = panel.scrollHeight;
+          }
+        });
+
+        // Stop polling on terminal status
+        if (data.status === "complete" || data.status === "failed") {
+          this.stopPolling();
+        }
+      } catch (e) {
+        console.error("[DeltaLake] Polling error:", e);
+      }
+    },
+
+    stopPolling() {
+      if (this.poller) {
+        clearInterval(this.poller);
+        this.poller = null;
+      }
+    },
+
+    destroy() {
+      this.stopPolling();
+    },
+  }));
+
+  // Handle log panel scroll detection
+  document.addEventListener("scroll", (e) => {
+    if (e.target.classList && e.target.classList.contains("log-panel")) {
+      const panel = e.target;
+      const atBottom =
+        panel.scrollHeight - panel.scrollTop - panel.clientHeight < 20;
+      // Find the Alpine component — best-effort
+      const component = Alpine.$data(
+        document.querySelector("[x-data='deltalakeRunningExports']")
+      );
+      if (component) {
+        component.userScrolled = !atBottom;
+      }
+    }
+  }, true);
+});

--- a/static/js/deltalakeStep1.js
+++ b/static/js/deltalakeStep1.js
@@ -156,6 +156,7 @@ document.addEventListener("alpine:init", () => {
         store.state.rowCount = data.row_count;
         store.state.bytesPerRow = data.bytes_per_row;
         store.state.availableColumns = data.available_columns || [];
+        store.state.geometryColumns = data.geometry_columns || [];
         store.state.specs = data.specs;
         store.state.stepStatus[1].completed = true;
         store.saveState();

--- a/static/js/deltalakeStep1.js
+++ b/static/js/deltalakeStep1.js
@@ -4,6 +4,7 @@ document.addEventListener("alpine:init", () => {
     version: Alpine.store("dlWizard").state.version || "",
     tableName: Alpine.store("dlWizard").state.tableName || "",
     targetPartitionSizeMb: Alpine.store("dlWizard").state.targetPartitionSizeMb || 256,
+    bloomFilterFpp: Alpine.store("dlWizard").state.bloomFilterFpp || 0.001,
     versions: [],
     tables: [],
     loadingVersions: false,
@@ -116,8 +117,10 @@ document.addEventListener("alpine:init", () => {
         store.state.version = parseInt(this.version);
         store.state.tableName = this.tableName;
         store.state.targetPartitionSizeMb = this.targetPartitionSizeMb;
+        store.state.bloomFilterFpp = this.bloomFilterFpp;
         store.state.rowCount = data.row_count;
         store.state.bytesPerRow = data.bytes_per_row;
+        store.state.availableColumns = data.available_columns || [];
         store.state.specs = data.specs;
         store.state.stepStatus[1].completed = true;
         store.saveState();

--- a/static/js/deltalakeStep1.js
+++ b/static/js/deltalakeStep1.js
@@ -11,6 +11,8 @@ document.addEventListener("alpine:init", () => {
     loadingTables: false,
     discovering: false,
     error: null,
+    existingExports: [],
+    checkingExists: false,
 
     init() {
       if (this.datastack) {
@@ -36,6 +38,7 @@ document.addEventListener("alpine:init", () => {
       this.tableName = "";
       this.tables = [];
       this.error = null;
+      this.existingExports = [];
       if (this.version) {
         await this.fetchTables();
       }
@@ -89,6 +92,38 @@ document.addEventListener("alpine:init", () => {
         this.error = `Error loading tables: ${e.message}`;
       } finally {
         this.loadingTables = false;
+      }
+    },
+
+    async onTableChange() {
+      this.existingExports = [];
+      this.error = null;
+      if (this.tableName && this.version && this.datastack) {
+        await this.checkExists();
+      }
+    },
+
+    async checkExists() {
+      this.checkingExists = true;
+      try {
+        const resp = await fetch("/materialize/deltalake/api/check-exists", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            datastack: this.datastack,
+            version: parseInt(this.version),
+            table_name: this.tableName,
+          }),
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          this.existingExports = data.existing_specs || [];
+        }
+      } catch (e) {
+        // Non-critical — don't block the user on check failure.
+        console.warn("[DeltaLake] check-exists failed:", e);
+      } finally {
+        this.checkingExists = false;
       }
     },
 

--- a/static/js/deltalakeStep1.js
+++ b/static/js/deltalakeStep1.js
@@ -44,13 +44,13 @@ document.addEventListener("alpine:init", () => {
       this.loadingVersions = true;
       try {
         const resp = await fetch(
-          `/materialize/api/v3/aligned_volumes/${this.datastack}`
+          `/materialize/api/v3/datastack/${this.datastack}/versions`
         );
         if (!resp.ok) throw new Error("Failed to fetch versions");
         const data = await resp.json();
-        this.versions = data.sort((a, b) => b.version - a.version);
+        this.versions = data.sort((a, b) => b - a);
         if (this.versions.length > 0 && !this.version) {
-          this.version = this.versions[0].version;
+          this.version = this.versions[0];
           await this.fetchTables();
         }
       } catch (e) {
@@ -63,13 +63,26 @@ document.addEventListener("alpine:init", () => {
     async fetchTables() {
       this.loadingTables = true;
       try {
-        const resp = await fetch(
-          `/materialize/api/v3/aligned_volumes/${this.datastack}/version/${this.version}`
-        );
-        if (!resp.ok) throw new Error("Failed to fetch tables");
-        const data = await resp.json();
-        this.tables = data.sort((a, b) =>
-          a.table_name.localeCompare(b.table_name)
+        const [tablesResp, viewsResp] = await Promise.all([
+          fetch(
+            `/materialize/api/v3/datastack/${this.datastack}/version/${this.version}/tables`
+          ),
+          fetch(
+            `/materialize/api/v3/datastack/${this.datastack}/version/${this.version}/views`
+          ),
+        ]);
+        if (!tablesResp.ok) throw new Error("Failed to fetch tables");
+        const tableNames = await tablesResp.json();
+        const tables = tableNames.map((name) => ({ name, type: "table" }));
+
+        let views = [];
+        if (viewsResp.ok) {
+          const viewData = await viewsResp.json();
+          views = Object.keys(viewData).map((name) => ({ name, type: "view" }));
+        }
+
+        this.tables = [...tables, ...views].sort((a, b) =>
+          a.name.localeCompare(b.name)
         );
       } catch (e) {
         this.error = `Error loading tables: ${e.message}`;

--- a/static/js/deltalakeStep1.js
+++ b/static/js/deltalakeStep1.js
@@ -1,0 +1,123 @@
+document.addEventListener("alpine:init", () => {
+  Alpine.data("deltalakeStep1", () => ({
+    datastack: Alpine.store("dlWizard").state.datastack || "",
+    version: Alpine.store("dlWizard").state.version || "",
+    tableName: Alpine.store("dlWizard").state.tableName || "",
+    targetPartitionSizeMb: Alpine.store("dlWizard").state.targetPartitionSizeMb || 256,
+    versions: [],
+    tables: [],
+    loadingVersions: false,
+    loadingTables: false,
+    discovering: false,
+    error: null,
+
+    init() {
+      if (this.datastack) {
+        this.fetchVersions();
+      }
+      if (this.version) {
+        this.fetchTables();
+      }
+    },
+
+    async onDatastackChange() {
+      this.version = "";
+      this.tableName = "";
+      this.versions = [];
+      this.tables = [];
+      this.error = null;
+      if (this.datastack) {
+        await this.fetchVersions();
+      }
+    },
+
+    async onVersionChange() {
+      this.tableName = "";
+      this.tables = [];
+      this.error = null;
+      if (this.version) {
+        await this.fetchTables();
+      }
+    },
+
+    async fetchVersions() {
+      this.loadingVersions = true;
+      try {
+        const resp = await fetch(
+          `/materialize/api/v3/aligned_volumes/${this.datastack}`
+        );
+        if (!resp.ok) throw new Error("Failed to fetch versions");
+        const data = await resp.json();
+        this.versions = data.sort((a, b) => b.version - a.version);
+        if (this.versions.length > 0 && !this.version) {
+          this.version = this.versions[0].version;
+          await this.fetchTables();
+        }
+      } catch (e) {
+        this.error = `Error loading versions: ${e.message}`;
+      } finally {
+        this.loadingVersions = false;
+      }
+    },
+
+    async fetchTables() {
+      this.loadingTables = true;
+      try {
+        const resp = await fetch(
+          `/materialize/api/v3/aligned_volumes/${this.datastack}/version/${this.version}`
+        );
+        if (!resp.ok) throw new Error("Failed to fetch tables");
+        const data = await resp.json();
+        this.tables = data.sort((a, b) =>
+          a.table_name.localeCompare(b.table_name)
+        );
+      } catch (e) {
+        this.error = `Error loading tables: ${e.message}`;
+      } finally {
+        this.loadingTables = false;
+      }
+    },
+
+    async discoverSpecs() {
+      this.discovering = true;
+      this.error = null;
+      try {
+        const resp = await fetch("/materialize/deltalake/api/discover-specs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            datastack: this.datastack,
+            version: parseInt(this.version),
+            table_name: this.tableName,
+            target_partition_size_mb: this.targetPartitionSizeMb,
+          }),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+          throw new Error(data.error || "Discovery failed");
+        }
+
+        // Save to wizard store
+        const store = Alpine.store("dlWizard");
+        store.state.datastack = this.datastack;
+        store.state.version = parseInt(this.version);
+        store.state.tableName = this.tableName;
+        store.state.targetPartitionSizeMb = this.targetPartitionSizeMb;
+        store.state.rowCount = data.row_count;
+        store.state.bytesPerRow = data.bytes_per_row;
+        store.state.specs = data.specs;
+        store.state.stepStatus[1].completed = true;
+        store.saveState();
+
+        // Navigate to step 2
+        store.state.currentStep = 2;
+        store.saveState();
+        window.location.href = "/materialize/deltalake/step2";
+      } catch (e) {
+        this.error = e.message;
+      } finally {
+        this.discovering = false;
+      }
+    },
+  }));
+});

--- a/static/js/deltalakeStep2.js
+++ b/static/js/deltalakeStep2.js
@@ -8,15 +8,10 @@ document.addEventListener("alpine:init", () => {
     recalculating: false,
     error: null,
 
-    // --- Partition column helpers ---
+    // --- Shared column helpers ---
 
-    /**
-     * Columns shown in the partition dropdown.
-     * Hides internal computed columns (_morton, _x, _y, _z suffixes of geometry cols).
-     * Shows the original geometry column names (selectable for spatial partitioning).
-     * For specs that already have a morton partition_by, shows the source geometry col.
-     */
-    partitionColumns(spec) {
+    /** Set of internal computed columns to hide from dropdowns. */
+    _hiddenGeoColumns() {
       const hidden = new Set();
       for (const geo of this.geometryColumns) {
         hidden.add(`${geo}_morton`);
@@ -24,6 +19,41 @@ document.addEventListener("alpine:init", () => {
         hidden.add(`${geo}_y`);
         hidden.add(`${geo}_z`);
       }
+      return hidden;
+    },
+
+    /** Display name for a column in dropdowns. Appends * to spatial columns. */
+    columnDisplayName(col) {
+      if (this.geometryColumns.includes(col)) {
+        return `${col} *`;
+      }
+      return col;
+    },
+
+    /** Display label for z-order badges. Maps _morton columns to friendly name with *. */
+    zorderBadgeLabel(col) {
+      for (const geo of this.geometryColumns) {
+        if (col === `${geo}_morton`) {
+          return `${geo} *`;
+        }
+      }
+      return col;
+    },
+
+    /** Check if a z-order column is a morton-encoded spatial column. */
+    isMortonZorderCol(col) {
+      return this.geometryColumns.some(geo => col === `${geo}_morton`);
+    },
+
+    // --- Partition column helpers ---
+
+    /**
+     * Columns shown in the partition dropdown.
+     * Hides internal computed columns (_morton, _x, _y, _z suffixes of geometry cols).
+     * Shows the original geometry column names (selectable for spatial partitioning).
+     */
+    partitionColumns(spec) {
+      const hidden = this._hiddenGeoColumns();
       return this.availableColumns.filter((c) => !hidden.has(c));
     },
 
@@ -63,12 +93,32 @@ document.addEventListener("alpine:init", () => {
     },
 
     // --- Z-order column management ---
+
+    /**
+     * Columns shown in the z-order dropdown.
+     * Hides internal computed columns and already-selected columns.
+     * If a geometry column's _morton version is already selected, hides the original too.
+     */
+    zorderSelectableColumns(spec) {
+      const hidden = this._hiddenGeoColumns();
+      const selected = new Set(spec.zorder_columns || []);
+      const selectedGeos = new Set();
+      for (const geo of this.geometryColumns) {
+        if (selected.has(`${geo}_morton`)) {
+          selectedGeos.add(geo);
+        }
+      }
+      return this.availableColumns.filter(c => !hidden.has(c) && !selected.has(c) && !selectedGeos.has(c));
+    },
+
     addZorderColumn(specIdx, col) {
       if (!col) return;
       const spec = this.specs[specIdx];
       if (!spec.zorder_columns) spec.zorder_columns = [];
-      if (!spec.zorder_columns.includes(col)) {
-        spec.zorder_columns.push(col);
+      // Geometry columns are stored as their morton-encoded equivalent
+      const storeCol = this.geometryColumns.includes(col) ? `${col}_morton` : col;
+      if (!spec.zorder_columns.includes(storeCol)) {
+        spec.zorder_columns.push(storeCol);
         this.syncStore();
       }
     },

--- a/static/js/deltalakeStep2.js
+++ b/static/js/deltalakeStep2.js
@@ -58,6 +58,7 @@ document.addEventListener("alpine:init", () => {
     addSpec() {
       this.specs.push({
         _editable: true,
+        name: "",
         partition_by: null,
         partition_strategy: "percentile_range",
         n_partitions: null,
@@ -71,11 +72,7 @@ document.addEventListener("alpine:init", () => {
     },
 
     unusedPartitionColumns(currentIdx) {
-      const used = this.specs
-        .filter((_, i) => i !== currentIdx)
-        .map((s) => s.partition_by)
-        .filter(Boolean);
-      return this.availableColumns.filter((c) => !used.includes(c));
+      return this.availableColumns;
     },
 
     removeSpec(idx) {

--- a/static/js/deltalakeStep2.js
+++ b/static/js/deltalakeStep2.js
@@ -94,6 +94,8 @@ document.addEventListener("alpine:init", () => {
           body: JSON.stringify({
             row_count: this.rowCount,
             bytes_per_row: this.bytesPerRow,
+            target_partition_size_mb:
+              Alpine.store("dlWizard").state.targetPartitionSizeMb,
             specs: specsForCalc,
           }),
         });

--- a/static/js/deltalakeStep2.js
+++ b/static/js/deltalakeStep2.js
@@ -4,8 +4,63 @@ document.addEventListener("alpine:init", () => {
     rowCount: Alpine.store("dlWizard").state.rowCount,
     bytesPerRow: Alpine.store("dlWizard").state.bytesPerRow,
     availableColumns: Alpine.store("dlWizard").state.availableColumns || [],
+    geometryColumns: Alpine.store("dlWizard").state.geometryColumns || [],
     recalculating: false,
     error: null,
+
+    // --- Partition column helpers ---
+
+    /**
+     * Columns shown in the partition dropdown.
+     * Hides internal computed columns (_morton, _x, _y, _z suffixes of geometry cols).
+     * Shows the original geometry column names (selectable for spatial partitioning).
+     * For specs that already have a morton partition_by, shows the source geometry col.
+     */
+    partitionColumns(spec) {
+      const hidden = new Set();
+      for (const geo of this.geometryColumns) {
+        hidden.add(`${geo}_morton`);
+        hidden.add(`${geo}_x`);
+        hidden.add(`${geo}_y`);
+        hidden.add(`${geo}_z`);
+      }
+      return this.availableColumns.filter((c) => !hidden.has(c));
+    },
+
+    /**
+     * Display value for the partition dropdown.
+     * For spatial specs, shows the geometry column name rather than the internal _morton name.
+     */
+    partitionDisplayValue(spec) {
+      if (spec.source_geometry_column) {
+        return spec.source_geometry_column;
+      }
+      return spec.partition_by;
+    },
+
+    /**
+     * Handle partition column change. Auto-derives morton config for geometry columns.
+     */
+    onPartitionChange(specIdx, selectedCol) {
+      const spec = this.specs[specIdx];
+      if (this.geometryColumns.includes(selectedCol)) {
+        // Spatial column selected → auto-derive morton partitioning
+        spec.source_geometry_column = selectedCol;
+        spec.partition_by = `${selectedCol}_morton`;
+        spec.partition_strategy = "uniform_range";
+        // Auto-add the morton column to z-order if not already present
+        if (!spec.zorder_columns) spec.zorder_columns = [];
+        const mortonCol = `${selectedCol}_morton`;
+        if (!spec.zorder_columns.includes(mortonCol)) {
+          spec.zorder_columns = [mortonCol, ...spec.zorder_columns.filter(c => c !== mortonCol)];
+        }
+      } else {
+        // Non-spatial column (or flat)
+        spec.source_geometry_column = null;
+        spec.partition_by = selectedCol || null;
+      }
+      this.syncStore();
+    },
 
     // --- Z-order column management ---
     addZorderColumn(specIdx, col) {

--- a/static/js/deltalakeStep2.js
+++ b/static/js/deltalakeStep2.js
@@ -8,6 +8,23 @@ document.addEventListener("alpine:init", () => {
     recalculating: false,
     error: null,
 
+    init() {
+      // Ensure source_geometry_column is populated for specs whose
+      // partition_by matches a known geometry column's morton form.
+      // Guards against stale caches or serialization round-trips that
+      // may have dropped the field.
+      for (const spec of this.specs) {
+        if (!spec.source_geometry_column && spec.partition_by) {
+          for (const geo of this.geometryColumns) {
+            if (spec.partition_by === `${geo}_morton`) {
+              spec.source_geometry_column = geo;
+              break;
+            }
+          }
+        }
+      }
+    },
+
     // --- Shared column helpers ---
 
     /** Set of internal computed columns to hide from dropdowns. */
@@ -78,12 +95,6 @@ document.addEventListener("alpine:init", () => {
         spec.source_geometry_column = selectedCol;
         spec.partition_by = `${selectedCol}_morton`;
         spec.partition_strategy = "uniform_range";
-        // Auto-add the morton column to z-order if not already present
-        if (!spec.zorder_columns) spec.zorder_columns = [];
-        const mortonCol = `${selectedCol}_morton`;
-        if (!spec.zorder_columns.includes(mortonCol)) {
-          spec.zorder_columns = [mortonCol, ...spec.zorder_columns.filter(c => c !== mortonCol)];
-        }
       } else {
         // Non-spatial column (or flat)
         spec.source_geometry_column = null;

--- a/static/js/deltalakeStep2.js
+++ b/static/js/deltalakeStep2.js
@@ -1,0 +1,47 @@
+document.addEventListener("alpine:init", () => {
+  Alpine.data("deltalakeStep2", () => ({
+    specs: Alpine.store("dlWizard").state.specs || [],
+    rowCount: Alpine.store("dlWizard").state.rowCount,
+    bytesPerRow: Alpine.store("dlWizard").state.bytesPerRow,
+    recalculating: false,
+    error: null,
+
+    removeSpec(idx) {
+      if (this.specs.length <= 1) return;
+      this.specs.splice(idx, 1);
+      Alpine.store("dlWizard").state.specs = this.specs;
+      Alpine.store("dlWizard").saveState();
+    },
+
+    async recalculate() {
+      this.recalculating = true;
+      this.error = null;
+      try {
+        // Mark specs with explicit n_partitions as fixed, set others to "auto"
+        const specsForCalc = this.specs.map((s) => ({ ...s }));
+
+        const resp = await fetch("/materialize/deltalake/api/recalculate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            row_count: this.rowCount,
+            bytes_per_row: this.bytesPerRow,
+            specs: specsForCalc,
+          }),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+          throw new Error(data.error || "Recalculation failed");
+        }
+
+        this.specs = data.specs;
+        Alpine.store("dlWizard").state.specs = this.specs;
+        Alpine.store("dlWizard").saveState();
+      } catch (e) {
+        this.error = e.message;
+      } finally {
+        this.recalculating = false;
+      }
+    },
+  }));
+});

--- a/static/js/deltalakeStep2.js
+++ b/static/js/deltalakeStep2.js
@@ -140,26 +140,18 @@ document.addEventListener("alpine:init", () => {
       this.recalculating = true;
       this.error = null;
       try {
-        // Only recalculate specs where n_partitions is "auto" or null
-        const specsForCalc = this.specs.map((s) => ({ ...s }));
+        const store = Alpine.store("dlWizard").state;
+        const globalTarget = store.targetPartitionSizeMb || 256;
 
-        const resp = await fetch("/materialize/deltalake/api/recalculate", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            row_count: this.rowCount,
-            bytes_per_row: this.bytesPerRow,
-            target_partition_size_mb:
-              Alpine.store("dlWizard").state.targetPartitionSizeMb,
-            specs: specsForCalc,
-          }),
-        });
-        const data = await resp.json();
-        if (!resp.ok) {
-          throw new Error(data.error || "Recalculation failed");
+        for (const spec of this.specs) {
+          if (spec.n_partitions === "auto" || spec.n_partitions == null) {
+            const targetMb = spec.target_file_size_mb || globalTarget;
+            const targetBytes = targetMb * 1024 * 1024;
+            const totalBytes = this.rowCount * this.bytesPerRow;
+            spec.n_partitions = Math.max(1, Math.ceil(totalBytes / targetBytes));
+          }
         }
 
-        this.specs = data.specs;
         this.syncStore();
       } catch (e) {
         this.error = e.message;

--- a/static/js/deltalakeStep2.js
+++ b/static/js/deltalakeStep2.js
@@ -3,21 +3,92 @@ document.addEventListener("alpine:init", () => {
     specs: Alpine.store("dlWizard").state.specs || [],
     rowCount: Alpine.store("dlWizard").state.rowCount,
     bytesPerRow: Alpine.store("dlWizard").state.bytesPerRow,
+    availableColumns: Alpine.store("dlWizard").state.availableColumns || [],
     recalculating: false,
     error: null,
+
+    // --- Z-order column management ---
+    addZorderColumn(specIdx, col) {
+      if (!col) return;
+      const spec = this.specs[specIdx];
+      if (!spec.zorder_columns) spec.zorder_columns = [];
+      if (!spec.zorder_columns.includes(col)) {
+        spec.zorder_columns.push(col);
+        this.syncStore();
+      }
+    },
+
+    removeZorderColumn(specIdx, colIdx) {
+      this.specs[specIdx].zorder_columns.splice(colIdx, 1);
+      this.syncStore();
+    },
+
+    moveZorderColumn(specIdx, colIdx, direction) {
+      const cols = this.specs[specIdx].zorder_columns;
+      const newIdx = colIdx + direction;
+      if (newIdx < 0 || newIdx >= cols.length) return;
+      [cols[colIdx], cols[newIdx]] = [cols[newIdx], cols[colIdx]];
+      this.syncStore();
+    },
+
+    // --- Bloom filter column management ---
+    toggleBloomColumn(specIdx, col) {
+      const spec = this.specs[specIdx];
+      if (!spec.bloom_filter_columns) spec.bloom_filter_columns = [];
+      const idx = spec.bloom_filter_columns.indexOf(col);
+      if (idx === -1) {
+        spec.bloom_filter_columns.push(col);
+      } else {
+        spec.bloom_filter_columns.splice(idx, 1);
+      }
+      this.syncStore();
+    },
+
+    hasBloomColumn(specIdx, col) {
+      const spec = this.specs[specIdx];
+      return (spec.bloom_filter_columns || []).includes(col);
+    },
+
+    // --- Helpers ---
+    syncStore() {
+      Alpine.store("dlWizard").state.specs = this.specs;
+      Alpine.store("dlWizard").saveState();
+    },
+
+    addSpec() {
+      this.specs.push({
+        _editable: true,
+        partition_by: null,
+        partition_strategy: "percentile_range",
+        n_partitions: null,
+        target_file_size_mb: null,
+        bloom_filter_fpp: null,
+        zorder_columns: [],
+        bloom_filter_columns: [],
+        source_geometry_column: null,
+      });
+      this.syncStore();
+    },
+
+    unusedPartitionColumns(currentIdx) {
+      const used = this.specs
+        .filter((_, i) => i !== currentIdx)
+        .map((s) => s.partition_by)
+        .filter(Boolean);
+      return this.availableColumns.filter((c) => !used.includes(c));
+    },
 
     removeSpec(idx) {
       if (this.specs.length <= 1) return;
       this.specs.splice(idx, 1);
-      Alpine.store("dlWizard").state.specs = this.specs;
-      Alpine.store("dlWizard").saveState();
+      this.syncStore();
     },
 
     async recalculate() {
       this.recalculating = true;
       this.error = null;
       try {
-        // Mark specs with explicit n_partitions as fixed, set others to "auto"
+        // Only recalculate specs where n_partitions is "auto" or null
         const specsForCalc = this.specs.map((s) => ({ ...s }));
 
         const resp = await fetch("/materialize/deltalake/api/recalculate", {
@@ -35,8 +106,7 @@ document.addEventListener("alpine:init", () => {
         }
 
         this.specs = data.specs;
-        Alpine.store("dlWizard").state.specs = this.specs;
-        Alpine.store("dlWizard").saveState();
+        this.syncStore();
       } catch (e) {
         this.error = e.message;
       } finally {

--- a/static/js/deltalakeStep3.js
+++ b/static/js/deltalakeStep3.js
@@ -22,12 +22,15 @@ document.addEventListener("alpine:init", () => {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            output_specs: state.specs.map((s) => ({
-              ...s,
-              bloom_filter_fpp: s.bloom_filter_columns?.length
-                ? (s.bloom_filter_fpp || state.bloomFilterFpp)
-                : null,
-            })),
+            output_specs: state.specs.map((s) => {
+              const { _editable, ...spec } = s;
+              return {
+                ...spec,
+                bloom_filter_fpp: spec.bloom_filter_columns?.length
+                  ? (spec.bloom_filter_fpp || state.bloomFilterFpp)
+                  : null,
+              };
+            }),
           }),
         });
         const data = await resp.json();

--- a/static/js/deltalakeStep3.js
+++ b/static/js/deltalakeStep3.js
@@ -2,11 +2,42 @@ document.addEventListener("alpine:init", () => {
   Alpine.data("deltalakeStep3", () => ({
     launching: false,
     error: null,
+    existingExports: [],
+    checkingExists: false,
+
+    init() {
+      this.checkExists();
+    },
 
     outputUri(spec) {
       const store = Alpine.store("dlWizard").state;
-      const lakeName = spec.partition_by || "flat";
-      return `${store.datastack}/v${store.version}/${store.tableName}/${lakeName}`;
+      return `${store.datastack}/v${store.version}/${store.tableName}/${spec.name}`;
+    },
+
+    async checkExists() {
+      this.checkingExists = true;
+      const state = Alpine.store("dlWizard").state;
+      const specNames = state.specs.map((s) => s.name);
+      try {
+        const resp = await fetch("/materialize/deltalake/api/check-exists", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            datastack: state.datastack,
+            version: state.version,
+            table_name: state.tableName,
+            spec_names: specNames,
+          }),
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          this.existingExports = data.existing_specs || [];
+        }
+      } catch (e) {
+        console.warn("[DeltaLake] check-exists failed:", e);
+      } finally {
+        this.checkingExists = false;
+      }
     },
 
     async launchExport() {

--- a/static/js/deltalakeStep3.js
+++ b/static/js/deltalakeStep3.js
@@ -35,12 +35,16 @@ document.addEventListener("alpine:init", () => {
           throw new Error(data.message || data.error || "Export launch failed");
         }
 
-        // Store export key info for monitoring page
-        store.state.exportKey = {
+        // Add to exports list for monitoring page
+        const newExport = {
           datastack: state.datastack,
           version: state.version,
           tableName: state.tableName,
+          submittedAt: new Date().toISOString(),
         };
+        // Clear wizard form state, then add the export
+        store.clearState();
+        store.state.exports.push(newExport);
         store.saveState();
 
         // Redirect to monitoring page

--- a/static/js/deltalakeStep3.js
+++ b/static/js/deltalakeStep3.js
@@ -43,6 +43,7 @@ document.addEventListener("alpine:init", () => {
           datastack: state.datastack,
           version: state.version,
           tableName: state.tableName,
+          jobId: data.job_id,
           submittedAt: new Date().toISOString(),
         };
         // Clear wizard form state, then add the export

--- a/static/js/deltalakeStep3.js
+++ b/static/js/deltalakeStep3.js
@@ -1,0 +1,50 @@
+document.addEventListener("alpine:init", () => {
+  Alpine.data("deltalakeStep3", () => ({
+    launching: false,
+    error: null,
+
+    outputUri(spec) {
+      const store = Alpine.store("dlWizard").state;
+      const lakeName = spec.partition_by || "flat";
+      return `${store.datastack}/v${store.version}/${store.tableName}/${lakeName}`;
+    },
+
+    async launchExport() {
+      this.launching = true;
+      this.error = null;
+      const store = Alpine.store("dlWizard");
+      const state = store.state;
+
+      try {
+        const url = `/materialize/api/v3/materialize/run/write_deltalake/datastack/${state.datastack}/version/${state.version}/table_name/${state.tableName}/`;
+
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            output_specs: state.specs,
+          }),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+          throw new Error(data.message || data.error || "Export launch failed");
+        }
+
+        // Store export key info for monitoring page
+        store.state.exportKey = {
+          datastack: state.datastack,
+          version: state.version,
+          tableName: state.tableName,
+        };
+        store.saveState();
+
+        // Redirect to monitoring page
+        window.location.href = "/materialize/deltalake/running-exports";
+      } catch (e) {
+        this.error = e.message;
+      } finally {
+        this.launching = false;
+      }
+    },
+  }));
+});

--- a/static/js/deltalakeStep3.js
+++ b/static/js/deltalakeStep3.js
@@ -16,13 +16,18 @@ document.addEventListener("alpine:init", () => {
       const state = store.state;
 
       try {
-        const url = `/materialize/api/v3/materialize/run/write_deltalake/datastack/${state.datastack}/version/${state.version}/table_name/${state.tableName}/`;
+        const url = `/materialize/api/v2/materialize/run/write_deltalake/datastack/${state.datastack}/version/${state.version}/table_name/${state.tableName}/`;
 
         const resp = await fetch(url, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            output_specs: state.specs,
+            output_specs: state.specs.map((s) => ({
+              ...s,
+              bloom_filter_fpp: s.bloom_filter_columns?.length
+                ? (s.bloom_filter_fpp || state.bloomFilterFpp)
+                : null,
+            })),
           }),
         });
         const data = await resp.json();

--- a/static/js/deltalakeWizardStore.js
+++ b/static/js/deltalakeWizardStore.js
@@ -18,6 +18,7 @@ document.addEventListener("alpine:init", () => {
       rowCount: null,
       bytesPerRow: null,
       availableColumns: [],
+      geometryColumns: [],
       bloomFilterFpp: 0.001,
       specs: [],
       // Export key for monitoring
@@ -66,6 +67,7 @@ document.addEventListener("alpine:init", () => {
       this.state.rowCount = null;
       this.state.bytesPerRow = null;
       this.state.availableColumns = [];
+      this.state.geometryColumns = [];
       this.state.bloomFilterFpp = 0.001;
       this.state.specs = [];
       this.state.exports = [];

--- a/static/js/deltalakeWizardStore.js
+++ b/static/js/deltalakeWizardStore.js
@@ -1,0 +1,80 @@
+document.addEventListener("alpine:init", () => {
+  Alpine.store("dlWizard", {
+    state: {
+      currentStep: 1,
+      totalSteps: 3,
+      stepStatus: {
+        1: { completed: false, valid: false },
+        2: { completed: false, valid: false },
+        3: { completed: false, valid: false },
+      },
+      // Step 1 data
+      datastack: null,
+      version: null,
+      tableName: null,
+      targetPartitionSizeMb: 256,
+      outputBucket: "",
+      // Step 2 data (populated by discovery)
+      rowCount: null,
+      bytesPerRow: null,
+      specs: [],
+      // Export key for monitoring
+      exportKey: null,
+    },
+
+    init() {
+      this.loadState();
+    },
+
+    loadState() {
+      const saved = localStorage.getItem("dlWizardState");
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved);
+          Object.assign(this.state, parsed);
+        } catch (e) {
+          console.warn("[dlWizard] Failed to parse saved state:", e);
+        }
+      }
+    },
+
+    saveState() {
+      localStorage.setItem("dlWizardState", JSON.stringify(this.state));
+    },
+
+    clearState() {
+      localStorage.removeItem("dlWizardState");
+      this.state.currentStep = 1;
+      this.state.stepStatus = {
+        1: { completed: false, valid: false },
+        2: { completed: false, valid: false },
+        3: { completed: false, valid: false },
+      };
+      this.state.datastack = null;
+      this.state.version = null;
+      this.state.tableName = null;
+      this.state.targetPartitionSizeMb = 256;
+      this.state.rowCount = null;
+      this.state.bytesPerRow = null;
+      this.state.specs = [];
+      this.state.exportKey = null;
+    },
+
+    next() {
+      if (this.state.currentStep < this.state.totalSteps) {
+        this.state.stepStatus[this.state.currentStep].completed = true;
+        this.state.currentStep++;
+        this.saveState();
+        window.location.href = `/materialize/deltalake/step${this.state.currentStep}`;
+      }
+    },
+
+    prev() {
+      if (this.state.currentStep > 1) {
+        this.state.currentStep--;
+        this.saveState();
+        window.location.href = `/materialize/deltalake/step${this.state.currentStep}`;
+      }
+    },
+  });
+});

--- a/static/js/deltalakeWizardStore.js
+++ b/static/js/deltalakeWizardStore.js
@@ -21,7 +21,7 @@ document.addEventListener("alpine:init", () => {
       bloomFilterFpp: 0.001,
       specs: [],
       // Export key for monitoring
-      exportKey: null,
+      exports: [],
     },
 
     init() {
@@ -61,7 +61,7 @@ document.addEventListener("alpine:init", () => {
       this.state.availableColumns = [];
       this.state.bloomFilterFpp = 0.001;
       this.state.specs = [];
-      this.state.exportKey = null;
+      this.state.exports = [];
     },
 
     next() {

--- a/static/js/deltalakeWizardStore.js
+++ b/static/js/deltalakeWizardStore.js
@@ -17,6 +17,8 @@ document.addEventListener("alpine:init", () => {
       // Step 2 data (populated by discovery)
       rowCount: null,
       bytesPerRow: null,
+      availableColumns: [],
+      bloomFilterFpp: 0.001,
       specs: [],
       // Export key for monitoring
       exportKey: null,
@@ -56,6 +58,8 @@ document.addEventListener("alpine:init", () => {
       this.state.targetPartitionSizeMb = 256;
       this.state.rowCount = null;
       this.state.bytesPerRow = null;
+      this.state.availableColumns = [];
+      this.state.bloomFilterFpp = 0.001;
       this.state.specs = [];
       this.state.exportKey = null;
     },

--- a/static/js/deltalakeWizardStore.js
+++ b/static/js/deltalakeWizardStore.js
@@ -38,6 +38,13 @@ document.addEventListener("alpine:init", () => {
           console.warn("[dlWizard] Failed to parse saved state:", e);
         }
       }
+      // Recompute stepStatus from currentStep so stale completions don't persist
+      for (let s = 1; s <= this.state.totalSteps; s++) {
+        if (!this.state.stepStatus[s]) {
+          this.state.stepStatus[s] = { completed: false, valid: false };
+        }
+        this.state.stepStatus[s].completed = s < this.state.currentStep;
+      }
     },
 
     saveState() {

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,6 +29,9 @@
                 <a href="{{ url_for('deltalake.wizard_step', step_number=1) }}">Delta Lake Export</a>
             </li>
             <li>
+                <a href="{{ url_for('deltalake.running_exports_page') }}">Running Exports</a>
+            </li>
+            <li>
                 <a href="/materialize/api/doc">API doc</a>
             </li>
         </ul>

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,9 @@
                 <a href="{{ url_for('upload.running_uploads_page') }}">Running Uploads</a>
             </li>
             <li>
+                <a href="{{ url_for('deltalake.wizard_step', step_number=1) }}">Delta Lake Export</a>
+            </li>
+            <li>
                 <a href="/materialize/api/doc">API doc</a>
             </li>
         </ul>

--- a/templates/deltalake/running_exports.html
+++ b/templates/deltalake/running_exports.html
@@ -5,7 +5,6 @@
 <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 <script src="{{ url_for('static', filename='js/deltalakeWizardStore.js') }}"></script>
 <script src="{{ url_for('static', filename='js/deltalakeRunningExports.js') }}"></script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
 <style>
     .export-card {
         margin-bottom: 1.5rem;

--- a/templates/deltalake/running_exports.html
+++ b/templates/deltalake/running_exports.html
@@ -15,6 +15,7 @@
     .status-complete { border-left: 5px solid #28a745; }
     .status-failed { border-left: 5px solid #dc3545; }
     .status-discovering_specs,
+    .status-resolving_specs,
     .status-computing_boundaries { border-left: 5px solid #17a2b8; }
     .status-streaming { border-left: 5px solid #007bff; }
     .status-optimizing { border-left: 5px solid #6f42c1; }
@@ -71,7 +72,7 @@
     <div x-show="exports.length > 0" class="row row-cols-1 g-4">
         <template x-for="(exp, idx) in exports" :key="exportId(exp)">
             <div class="col">
-                <div class="card export-card" :class="`status-${getProgress(exp).phase || getProgress(exp).status || 'idle'}`">
+                <div class="card export-card" :class="`status-${getProgress(exp).status === 'failed' ? 'failed' : (getProgress(exp).phase || getProgress(exp).status || 'idle')}`">
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <strong x-text="`${exp.tableName} (v${exp.version})`"></strong>
                         <div class="d-flex align-items-center gap-2">
@@ -93,14 +94,20 @@
                     </div>
                     <div class="card-body">
                         <!-- Queued / waiting state -->
-                        <div x-show="!getProgress(exp).status || getProgress(exp).status === 'pending'" class="text-center py-3">
+                        <div x-show="(!getProgress(exp).status || getProgress(exp).status === 'pending') && getProgress(exp).status !== 'failed'" class="text-center py-3">
                             <i class="fas fa-spinner fa-spin fa-2x text-info mb-2"></i>
                             <p class="mb-1"><strong>Export queued</strong></p>
                             <p class="text-muted small mb-0">Waiting for worker to pick up the task...</p>
                             <p class="text-muted small mt-1" x-show="exp.submittedAt" x-text="'Submitted: ' + new Date(exp.submittedAt).toLocaleString()"></p>
                         </div>
+                        <!-- Failed state -->
+                        <div x-show="getProgress(exp).status === 'failed'" class="text-center py-3">
+                            <i class="fas fa-times-circle fa-2x text-danger mb-2"></i>
+                            <p class="mb-1"><strong class="text-danger">Export Failed</strong></p>
+                            <p class="text-muted small mb-0" x-show="getProgress(exp).last_updated" x-text="'Failed at: ' + new Date(getProgress(exp).last_updated).toLocaleString()"></p>
+                        </div>
                         <!-- Progress bar -->
-                        <div class="mb-3" x-show="getProgress(exp).total_rows">
+                        <div class="mb-3" x-show="getProgress(exp).total_rows && getProgress(exp).status !== 'failed'">
                             <div class="d-flex justify-content-between mb-1">
                                 <small x-text="`${(getProgress(exp).rows_processed || 0).toLocaleString()} / ${(getProgress(exp).total_rows || 0).toLocaleString()} rows`"></small>
                                 <small x-text="`${(getProgress(exp).percent_complete || 0).toFixed(1)}%`"></small>
@@ -109,7 +116,6 @@
                                 <div class="progress-bar"
                                      :class="{
                                          'bg-success': getProgress(exp).status === 'complete',
-                                         'bg-danger': getProgress(exp).status === 'failed',
                                          'bg-primary progress-bar-striped progress-bar-animated': getProgress(exp).status === 'exporting'
                                      }"
                                      :style="`width: ${getProgress(exp).percent_complete || 0}%`">

--- a/templates/deltalake/running_exports.html
+++ b/templates/deltalake/running_exports.html
@@ -1,0 +1,130 @@
+{% extends "base.html" %}
+{% block title %}Running Exports - MaterializationEngine{% endblock %}
+
+{% block html_head %}
+<script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+<script src="{{ url_for('static', filename='js/deltalakeWizardStore.js') }}"></script>
+<script src="{{ url_for('static', filename='js/deltalakeRunningExports.js') }}"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+<style>
+    .export-card {
+        margin-bottom: 1.5rem;
+        box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+    }
+    .status-exporting { border-left: 5px solid #007bff; }
+    .status-complete { border-left: 5px solid #28a745; }
+    .status-failed { border-left: 5px solid #dc3545; }
+    .status-discovering_specs,
+    .status-computing_boundaries { border-left: 5px solid #17a2b8; }
+    .status-streaming { border-left: 5px solid #007bff; }
+    .status-optimizing { border-left: 5px solid #6f42c1; }
+
+    .log-panel {
+        max-height: 300px;
+        overflow-y: auto;
+        background: #1e1e1e;
+        color: #d4d4d4;
+        font-family: 'Courier New', monospace;
+        font-size: 0.8rem;
+        padding: 0.75rem;
+        border-radius: 4px;
+    }
+    .log-entry {
+        margin: 0;
+        padding: 2px 0;
+        white-space: pre-wrap;
+        word-break: break-all;
+    }
+    .error-panel {
+        border: 2px solid #dc3545;
+        background: #f8d7da;
+        color: #842029;
+        padding: 1rem;
+        border-radius: 4px;
+        white-space: pre-wrap;
+        word-break: break-all;
+    }
+    .progress-bar { transition: width 0.6s ease; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="container mt-4" x-data="deltalakeRunningExports">
+    <div class="d-flex justify-content-between align-items-center border-bottom pb-3 mb-4">
+        <h2><i class="fas fa-download me-2"></i>Delta Lake Exports</h2>
+        <a href="{{ url_for('deltalake.wizard_step', step_number=1) }}" class="btn btn-sm btn-primary">
+            <i class="fas fa-plus me-1"></i> New Export
+        </a>
+    </div>
+
+    <!-- No active export -->
+    <div x-show="!exportKey" class="text-center my-5">
+        <i class="fas fa-folder-open fa-3x text-muted mb-3"></i>
+        <h4>No Active Export</h4>
+        <p class="text-muted">Start a new export from the wizard.</p>
+        <a href="{{ url_for('deltalake.wizard_step', step_number=1) }}" class="btn btn-primary mt-2">
+            <i class="fas fa-plus me-1"></i> Start Export
+        </a>
+    </div>
+
+    <!-- Export card grid (supports future N cards) -->
+    <div x-show="exportKey" class="row row-cols-1 g-4">
+        <div class="col">
+            <div class="card export-card" :class="`status-${progress.phase || progress.status || 'idle'}`">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <strong x-text="`${exportKey?.tableName} (v${exportKey?.version})`"></strong>
+                    <span class="badge"
+                          :class="{
+                              'bg-primary': progress.status === 'exporting',
+                              'bg-success': progress.status === 'complete',
+                              'bg-danger': progress.status === 'failed',
+                              'bg-info': !progress.status
+                          }"
+                          x-text="progress.phase || progress.status || 'pending'">
+                    </span>
+                </div>
+                <div class="card-body">
+                    <!-- Progress bar -->
+                    <div class="mb-3" x-show="progress.total_rows">
+                        <div class="d-flex justify-content-between mb-1">
+                            <small x-text="`${(progress.rows_processed || 0).toLocaleString()} / ${(progress.total_rows || 0).toLocaleString()} rows`"></small>
+                            <small x-text="`${(progress.percent_complete || 0).toFixed(1)}%`"></small>
+                        </div>
+                        <div class="progress" style="height: 20px;">
+                            <div class="progress-bar"
+                                 :class="{
+                                     'bg-success': progress.status === 'complete',
+                                     'bg-danger': progress.status === 'failed',
+                                     'bg-primary progress-bar-striped progress-bar-animated': progress.status === 'exporting'
+                                 }"
+                                 :style="`width: ${progress.percent_complete || 0}%`">
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Error panel -->
+                    <div x-show="progress.error" class="error-panel mb-3">
+                        <strong><i class="fas fa-exclamation-triangle me-1"></i>Error:</strong>
+                        <p class="mb-0 mt-1" x-text="progress.error"></p>
+                    </div>
+
+                    <!-- Log panel -->
+                    <div x-show="progress.log_entries && progress.log_entries.length > 0">
+                        <label class="form-label small text-muted">Log</label>
+                        <div class="log-panel" x-ref="logPanel">
+                            <template x-for="(entry, i) in (progress.log_entries || [])" :key="i">
+                                <p class="log-entry" x-text="entry"></p>
+                            </template>
+                        </div>
+                    </div>
+
+                    <!-- Last updated -->
+                    <div class="mt-2 text-muted small" x-show="progress.last_updated">
+                        Last updated: <span x-text="progress.last_updated"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/deltalake/running_exports.html
+++ b/templates/deltalake/running_exports.html
@@ -57,74 +57,90 @@
         </a>
     </div>
 
-    <!-- No active export -->
-    <div x-show="!exportKey" class="text-center my-5">
+    <!-- No exports -->
+    <div x-show="exports.length === 0" class="text-center my-5">
         <i class="fas fa-folder-open fa-3x text-muted mb-3"></i>
-        <h4>No Active Export</h4>
+        <h4>No Exports</h4>
         <p class="text-muted">Start a new export from the wizard.</p>
         <a href="{{ url_for('deltalake.wizard_step', step_number=1) }}" class="btn btn-primary mt-2">
             <i class="fas fa-plus me-1"></i> Start Export
         </a>
     </div>
 
-    <!-- Export card grid (supports future N cards) -->
-    <div x-show="exportKey" class="row row-cols-1 g-4">
-        <div class="col">
-            <div class="card export-card" :class="`status-${progress.phase || progress.status || 'idle'}`">
-                <div class="card-header d-flex justify-content-between align-items-center">
-                    <strong x-text="`${exportKey?.tableName} (v${exportKey?.version})`"></strong>
-                    <span class="badge"
-                          :class="{
-                              'bg-primary': progress.status === 'exporting',
-                              'bg-success': progress.status === 'complete',
-                              'bg-danger': progress.status === 'failed',
-                              'bg-info': !progress.status
-                          }"
-                          x-text="progress.phase || progress.status || 'pending'">
-                    </span>
-                </div>
-                <div class="card-body">
-                    <!-- Progress bar -->
-                    <div class="mb-3" x-show="progress.total_rows">
-                        <div class="d-flex justify-content-between mb-1">
-                            <small x-text="`${(progress.rows_processed || 0).toLocaleString()} / ${(progress.total_rows || 0).toLocaleString()} rows`"></small>
-                            <small x-text="`${(progress.percent_complete || 0).toFixed(1)}%`"></small>
+    <!-- Export cards -->
+    <div x-show="exports.length > 0" class="row row-cols-1 g-4">
+        <template x-for="(exp, idx) in exports" :key="exportId(exp)">
+            <div class="col">
+                <div class="card export-card" :class="`status-${getProgress(exp).phase || getProgress(exp).status || 'idle'}`">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <strong x-text="`${exp.tableName} (v${exp.version})`"></strong>
+                        <div class="d-flex align-items-center gap-2">
+                            <span class="badge"
+                                  :class="{
+                                      'bg-primary': getProgress(exp).status === 'exporting',
+                                      'bg-success': getProgress(exp).status === 'complete',
+                                      'bg-danger': getProgress(exp).status === 'failed',
+                                      'bg-info': !getProgress(exp).status || getProgress(exp).status === 'pending'
+                                  }"
+                                  x-text="getProgress(exp).phase || getProgress(exp).status || 'pending'">
+                            </span>
+                            <button class="btn btn-sm btn-outline-secondary"
+                                    @click="removeExport(idx)"
+                                    title="Dismiss">
+                                <i class="fas fa-times"></i>
+                            </button>
                         </div>
-                        <div class="progress" style="height: 20px;">
-                            <div class="progress-bar"
-                                 :class="{
-                                     'bg-success': progress.status === 'complete',
-                                     'bg-danger': progress.status === 'failed',
-                                     'bg-primary progress-bar-striped progress-bar-animated': progress.status === 'exporting'
-                                 }"
-                                 :style="`width: ${progress.percent_complete || 0}%`">
+                    </div>
+                    <div class="card-body">
+                        <!-- Queued / waiting state -->
+                        <div x-show="!getProgress(exp).status || getProgress(exp).status === 'pending'" class="text-center py-3">
+                            <i class="fas fa-spinner fa-spin fa-2x text-info mb-2"></i>
+                            <p class="mb-1"><strong>Export queued</strong></p>
+                            <p class="text-muted small mb-0">Waiting for worker to pick up the task...</p>
+                            <p class="text-muted small mt-1" x-show="exp.submittedAt" x-text="'Submitted: ' + new Date(exp.submittedAt).toLocaleString()"></p>
+                        </div>
+                        <!-- Progress bar -->
+                        <div class="mb-3" x-show="getProgress(exp).total_rows">
+                            <div class="d-flex justify-content-between mb-1">
+                                <small x-text="`${(getProgress(exp).rows_processed || 0).toLocaleString()} / ${(getProgress(exp).total_rows || 0).toLocaleString()} rows`"></small>
+                                <small x-text="`${(getProgress(exp).percent_complete || 0).toFixed(1)}%`"></small>
+                            </div>
+                            <div class="progress" style="height: 20px;">
+                                <div class="progress-bar"
+                                     :class="{
+                                         'bg-success': getProgress(exp).status === 'complete',
+                                         'bg-danger': getProgress(exp).status === 'failed',
+                                         'bg-primary progress-bar-striped progress-bar-animated': getProgress(exp).status === 'exporting'
+                                     }"
+                                     :style="`width: ${getProgress(exp).percent_complete || 0}%`">
+                                </div>
                             </div>
                         </div>
-                    </div>
 
-                    <!-- Error panel -->
-                    <div x-show="progress.error" class="error-panel mb-3">
-                        <strong><i class="fas fa-exclamation-triangle me-1"></i>Error:</strong>
-                        <p class="mb-0 mt-1" x-text="progress.error"></p>
-                    </div>
-
-                    <!-- Log panel -->
-                    <div x-show="progress.log_entries && progress.log_entries.length > 0">
-                        <label class="form-label small text-muted">Log</label>
-                        <div class="log-panel" x-ref="logPanel">
-                            <template x-for="(entry, i) in (progress.log_entries || [])" :key="i">
-                                <p class="log-entry" x-text="entry"></p>
-                            </template>
+                        <!-- Error panel -->
+                        <div x-show="getProgress(exp).error" class="error-panel mb-3">
+                            <strong><i class="fas fa-exclamation-triangle me-1"></i>Error:</strong>
+                            <p class="mb-0 mt-1" x-text="getProgress(exp).error"></p>
                         </div>
-                    </div>
 
-                    <!-- Last updated -->
-                    <div class="mt-2 text-muted small" x-show="progress.last_updated">
-                        Last updated: <span x-text="progress.last_updated"></span>
+                        <!-- Log panel -->
+                        <div x-show="getProgress(exp).log_entries && getProgress(exp).log_entries.length > 0">
+                            <label class="form-label small text-muted">Log</label>
+                            <div class="log-panel">
+                                <template x-for="(entry, i) in (getProgress(exp).log_entries || [])" :key="i">
+                                    <p class="log-entry" x-text="entry"></p>
+                                </template>
+                            </div>
+                        </div>
+
+                        <!-- Last updated -->
+                        <div class="mt-2 text-muted small" x-show="getProgress(exp).last_updated">
+                            Last updated: <span x-text="getProgress(exp).last_updated"></span>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        </template>
     </div>
 </div>
 {% endblock %}

--- a/templates/deltalake/step1.html
+++ b/templates/deltalake/step1.html
@@ -29,7 +29,7 @@
 
         <div class="col-md-4">
             <label class="form-label fw-bold">Table</label>
-            <select class="form-select" x-model="tableName" :disabled="!version || loadingTables">
+            <select class="form-select" x-model="tableName" @change="onTableChange()" :disabled="!version || loadingTables">
                 <option value="">Select a table...</option>
                 <template x-for="t in tables" :key="t.name">
                     <option :value="t.name" x-text="`${t.name} (${t.type})`"></option>
@@ -65,6 +65,24 @@
                 </div>
             </div>
         </div>
+    </div>
+
+    <!-- Existing export warning -->
+    <div x-show="existingExports.length > 0" class="alert alert-warning mt-4 mb-0">
+        <strong><i class="fas fa-exclamation-triangle me-1"></i>Export already exists</strong>
+        <p class="mb-1 mt-2">Delta Lake data already exists for this table/version at the following locations:</p>
+        <ul class="mb-1">
+            <template x-for="spec in existingExports" :key="spec.uri">
+                <li>
+                    <code x-text="spec.uri"></code>
+                    <span class="text-muted" x-text="`(${spec.row_count.toLocaleString()} rows)`"></span>
+                </li>
+            </template>
+        </ul>
+        <small class="text-muted">Re-exporting will fail unless the existing data is removed first.</small>
+    </div>
+    <div x-show="checkingExists" class="form-text mt-3">
+        <i class="fas fa-spinner fa-spin me-1"></i> Checking for existing exports...
     </div>
 
     <!-- Discover button -->

--- a/templates/deltalake/step1.html
+++ b/templates/deltalake/step1.html
@@ -18,8 +18,8 @@
             <label class="form-label fw-bold">Version</label>
             <select class="form-select" x-model="version" @change="onVersionChange()" :disabled="!datastack || loadingVersions">
                 <option value="">Select a version...</option>
-                <template x-for="v in versions" :key="v.version">
-                    <option :value="v.version" x-text="`v${v.version}`"></option>
+                <template x-for="v in versions" :key="v">
+                    <option :value="v" x-text="`v${v}`"></option>
                 </template>
             </select>
             <div x-show="loadingVersions" class="form-text">
@@ -31,8 +31,8 @@
             <label class="form-label fw-bold">Table</label>
             <select class="form-select" x-model="tableName" :disabled="!version || loadingTables">
                 <option value="">Select a table...</option>
-                <template x-for="t in tables" :key="t.table_name">
-                    <option :value="t.table_name" x-text="t.table_name"></option>
+                <template x-for="t in tables" :key="t.name">
+                    <option :value="t.name" x-text="`${t.name} (${t.type})`"></option>
                 </template>
             </select>
             <div x-show="loadingTables" class="form-text">

--- a/templates/deltalake/step1.html
+++ b/templates/deltalake/step1.html
@@ -1,0 +1,81 @@
+<div class="card-body" x-data="deltalakeStep1">
+    <h4 class="card-title mb-4">
+        <i class="fas fa-database me-2"></i>Select Table & Configuration
+    </h4>
+
+    <div class="row g-3">
+        <div class="col-md-4">
+            <label class="form-label fw-bold">Datastack</label>
+            <select class="form-select" x-model="datastack" @change="onDatastackChange()">
+                <option value="">Select a datastack...</option>
+                {% for ds in datastacks %}
+                <option value="{{ ds }}">{{ ds }}</option>
+                {% endfor %}
+            </select>
+        </div>
+
+        <div class="col-md-4">
+            <label class="form-label fw-bold">Version</label>
+            <select class="form-select" x-model="version" @change="onVersionChange()" :disabled="!datastack || loadingVersions">
+                <option value="">Select a version...</option>
+                <template x-for="v in versions" :key="v.version">
+                    <option :value="v.version" x-text="`v${v.version}`"></option>
+                </template>
+            </select>
+            <div x-show="loadingVersions" class="form-text">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading versions...
+            </div>
+        </div>
+
+        <div class="col-md-4">
+            <label class="form-label fw-bold">Table</label>
+            <select class="form-select" x-model="tableName" :disabled="!version || loadingTables">
+                <option value="">Select a table...</option>
+                <template x-for="t in tables" :key="t.table_name">
+                    <option :value="t.table_name" x-text="t.table_name"></option>
+                </template>
+            </select>
+            <div x-show="loadingTables" class="form-text">
+                <i class="fas fa-spinner fa-spin me-1"></i> Loading tables...
+            </div>
+        </div>
+    </div>
+
+    <!-- Advanced options (collapsible) -->
+    <div class="mt-4">
+        <a class="text-decoration-none" data-bs-toggle="collapse" href="#advancedOptions" role="button" aria-expanded="false">
+            <i class="fas fa-cog me-1"></i> Advanced Options
+        </a>
+        <div class="collapse mt-2" id="advancedOptions">
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label">Target Partition Size (MB)</label>
+                    <input type="number" class="form-control" x-model.number="targetPartitionSizeMb" min="1">
+                    <div class="form-text">Default from environment: {{ target_partition_size_mb }} MB</div>
+                </div>
+                <div class="col-md-8">
+                    <label class="form-label">Output Bucket</label>
+                    <input type="text" class="form-control" value="{{ output_bucket }}" disabled>
+                    <div class="form-text">Configured via environment (read-only)</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Discover button -->
+    <div class="mt-4 d-flex align-items-center gap-3">
+        <button class="btn btn-primary"
+                :disabled="!datastack || !version || !tableName || discovering"
+                @click="discoverSpecs()">
+            <template x-if="!discovering">
+                <span><i class="fas fa-search me-2"></i>Discover Specs</span>
+            </template>
+            <template x-if="discovering">
+                <span><i class="fas fa-spinner fa-spin me-2"></i>Discovering...</span>
+            </template>
+        </button>
+    </div>
+
+    <!-- Error display -->
+    <div x-show="error" class="alert alert-danger mt-3" x-text="error"></div>
+</div>

--- a/templates/deltalake/step1.html
+++ b/templates/deltalake/step1.html
@@ -49,11 +49,16 @@
         <div class="collapse mt-2" id="advancedOptions">
             <div class="row g-3">
                 <div class="col-md-4">
-                    <label class="form-label">Target Partition Size (MB)</label>
+                    <label class="form-label">Target File Size (MB)</label>
                     <input type="number" class="form-control" x-model.number="targetPartitionSizeMb" min="1">
                     <div class="form-text">Default from environment: {{ target_partition_size_mb }} MB</div>
                 </div>
-                <div class="col-md-8">
+                <div class="col-md-4">
+                    <label class="form-label">Bloom Filter FPP</label>
+                    <input type="number" class="form-control" x-model.number="bloomFilterFpp" step="0.0001" min="0.0001" max="1">
+                    <div class="form-text">False positive probability (default: {{ bloom_filter_fpp }})</div>
+                </div>
+                <div class="col-md-4">
                     <label class="form-label">Output Bucket</label>
                     <input type="text" class="form-control" value="{{ output_bucket }}" disabled>
                     <div class="form-text">Configured via environment (read-only)</div>

--- a/templates/deltalake/step2.html
+++ b/templates/deltalake/step2.html
@@ -50,19 +50,27 @@
                             <div class="col-md-3">
                                 <label class="form-label small fw-semibold text-start d-block">Partition By</label>
                                 <select class="form-select form-select-sm"
-                                        x-model="spec.partition_by"
-                                        @change="syncStore()">
-                                    <option :value="null">flat (no partition)</option>
-                                    <template x-for="col in availableColumns.filter(c => !c.endsWith('_morton') || spec.partition_by === c)" :key="col">
-                                        <option :value="col" x-text="col" :selected="spec.partition_by === col"></option>
+                                        :value="spec.source_geometry_column || spec.partition_by || ''"
+                                        @change="onPartitionChange(idx, $event.target.value)">
+                                    <option value="">flat (no partition)</option>
+                                    <template x-for="col in partitionColumns(spec)" :key="col">
+                                        <option :value="col" x-text="col"></option>
                                     </template>
                                 </select>
+                                <template x-if="spec.source_geometry_column">
+                                    <small class="form-text text-info">
+                                        <i class="fas fa-info-circle me-1"></i>
+                                        Spatial column — will be morton-encoded →
+                                        <code x-text="spec.partition_by"></code>
+                                        (uniform_range)
+                                    </small>
+                                </template>
                             </div>
                             <div class="col-md-3">
                                 <label class="form-label small fw-semibold text-start d-block">Strategy</label>
                                 <select class="form-select form-select-sm"
                                         x-model="spec.partition_strategy"
-                                        :disabled="!spec.partition_by"
+                                        :disabled="!spec.partition_by || !!spec.source_geometry_column"
                                         @change="syncStore()">
                                     <option value="percentile_range">percentile_range</option>
                                     <option value="uniform_range">uniform_range</option>

--- a/templates/deltalake/step2.html
+++ b/templates/deltalake/step2.html
@@ -53,7 +53,7 @@
                                         x-model="spec.partition_by"
                                         @change="syncStore()">
                                     <option :value="null">flat (no partition)</option>
-                                    <template x-for="col in availableColumns" :key="col">
+                                    <template x-for="col in availableColumns.filter(c => !c.endsWith('_morton') || spec.partition_by === c)" :key="col">
                                         <option :value="col" x-text="col" :selected="spec.partition_by === col"></option>
                                     </template>
                                 </select>
@@ -76,6 +76,7 @@
                                        placeholder="auto"
                                        :disabled="!spec.partition_by"
                                        @change="syncStore()">
+                                <small class="form-text text-muted">Leave empty to auto-calculate from target file size</small>
                             </div>
                             <div class="col-md-3">
                                 <label class="form-label small fw-semibold text-start d-block">Target File Size (MB)</label>

--- a/templates/deltalake/step2.html
+++ b/templates/deltalake/step2.html
@@ -13,10 +13,10 @@
                 <strong>Est. bytes/row:</strong> <span x-text="bytesPerRow"></span>
             </div>
             <div class="col-auto">
-                <strong>Global file size:</strong> <span x-text="$store.dlWizard.state.targetPartitionSizeMb + ' MB'"></span>
+                <strong>Default file size:</strong> <span x-text="$store.dlWizard.state.targetPartitionSizeMb + ' MB'"></span>
             </div>
             <div class="col-auto">
-                <strong>Global FPP:</strong> <span x-text="$store.dlWizard.state.bloomFilterFpp"></span>
+                <strong>Default FPP:</strong> <span x-text="$store.dlWizard.state.bloomFilterFpp"></span>
             </div>
         </div>
     </div>
@@ -74,7 +74,7 @@
                                 <label class="form-label small fw-semibold text-start d-block">Target File Size (MB)</label>
                                 <input type="number" class="form-control form-control-sm"
                                        x-model.number="spec.target_file_size_mb"
-                                       :placeholder="$store.dlWizard.state.targetPartitionSizeMb + ' (global)'"
+                                       :placeholder="$store.dlWizard.state.targetPartitionSizeMb + ' (default)'"
                                        min="1"
                                        @change="syncStore()">
                             </div>
@@ -134,7 +134,7 @@
                                 <label class="form-label small fw-semibold text-start d-block">Bloom Filter FPP</label>
                                 <input type="number" class="form-control form-control-sm"
                                        x-model.number="spec.bloom_filter_fpp"
-                                       :placeholder="$store.dlWizard.state.bloomFilterFpp + ' (global)'"
+                                       :placeholder="$store.dlWizard.state.bloomFilterFpp + ' (default)'"
                                        step="0.0001" min="0.0001" max="1"
                                        @change="syncStore()">
                             </div>

--- a/templates/deltalake/step2.html
+++ b/templates/deltalake/step2.html
@@ -27,7 +27,7 @@
             <div class="col-12">
                 <div class="card">
                     <div class="card-header d-flex justify-content-between align-items-center">
-                        <strong x-text="`Spec: ${spec.partition_by || 'flat'}`"></strong>
+                        <strong x-text="`Spec: ${spec.name || '(unnamed)'}`"></strong>
                         <button class="btn btn-sm btn-outline-danger"
                                 :disabled="specs.length <= 1"
                                 @click="removeSpec(idx)">
@@ -35,28 +35,34 @@
                         </button>
                     </div>
                     <div class="card-body">
+                        <!-- Row 0: Name -->
+                        <div class="row g-2 pb-3 mb-3" style="border-bottom: 1px solid #dee2e6">
+                            <div class="col-md-4">
+                                <label class="form-label small fw-semibold text-start d-block">Name <span class="fw-normal text-muted">(output folder name)</span></label>
+                                <input type="text" class="form-control form-control-sm"
+                                       x-model="spec.name"
+                                       placeholder="Required — output folder name"
+                                       @change="syncStore()">
+                            </div>
+                        </div>
                         <!-- Row 1: Partition params -->
                         <div class="row g-2 pb-3 mb-3" style="border-bottom: 1px solid #dee2e6">
                             <div class="col-md-3">
                                 <label class="form-label small fw-semibold text-start d-block">Partition By</label>
-                                <template x-if="spec._editable">
-                                    <select class="form-select form-select-sm"
-                                            x-model="spec.partition_by"
-                                            @change="syncStore()">
-                                        <option :value="null">flat (no partition)</option>
-                                        <template x-for="col in unusedPartitionColumns(idx)" :key="col">
-                                            <option :value="col" x-text="col"></option>
-                                        </template>
-                                    </select>
-                                </template>
-                                <template x-if="!spec._editable">
-                                    <input class="form-control form-control-sm" :value="spec.partition_by || 'flat'" disabled>
-                                </template>
+                                <select class="form-select form-select-sm"
+                                        x-model="spec.partition_by"
+                                        @change="syncStore()">
+                                    <option :value="null">flat (no partition)</option>
+                                    <template x-for="col in availableColumns" :key="col">
+                                        <option :value="col" x-text="col" :selected="spec.partition_by === col"></option>
+                                    </template>
+                                </select>
                             </div>
                             <div class="col-md-3">
                                 <label class="form-label small fw-semibold text-start d-block">Strategy</label>
                                 <select class="form-select form-select-sm"
                                         x-model="spec.partition_strategy"
+                                        :disabled="!spec.partition_by"
                                         @change="syncStore()">
                                     <option value="percentile_range">percentile_range</option>
                                     <option value="uniform_range">uniform_range</option>
@@ -68,6 +74,7 @@
                                 <input type="number" class="form-control form-control-sm"
                                        x-model.number="spec.n_partitions" min="1"
                                        placeholder="auto"
+                                       :disabled="!spec.partition_by"
                                        @change="syncStore()">
                             </div>
                             <div class="col-md-3">

--- a/templates/deltalake/step2.html
+++ b/templates/deltalake/step2.html
@@ -3,10 +3,22 @@
         <i class="fas fa-layer-group me-2"></i>Review Output Specs
     </h4>
 
-    <!-- Table metadata -->
-    <div class="alert alert-info d-flex gap-4 mb-4">
-        <span><strong>Row count:</strong> <span x-text="rowCount?.toLocaleString()"></span></span>
-        <span><strong>Est. bytes/row:</strong> <span x-text="bytesPerRow"></span></span>
+    <!-- Global settings -->
+    <div class="alert alert-info mb-4">
+        <div class="row g-3 align-items-end">
+            <div class="col-auto">
+                <strong>Row count:</strong> <span x-text="rowCount?.toLocaleString()"></span>
+            </div>
+            <div class="col-auto">
+                <strong>Est. bytes/row:</strong> <span x-text="bytesPerRow"></span>
+            </div>
+            <div class="col-auto">
+                <strong>Global file size:</strong> <span x-text="$store.dlWizard.state.targetPartitionSizeMb + ' MB'"></span>
+            </div>
+            <div class="col-auto">
+                <strong>Global FPP:</strong> <span x-text="$store.dlWizard.state.bloomFilterFpp"></span>
+            </div>
+        </div>
     </div>
 
     <!-- Spec cards -->
@@ -23,46 +35,121 @@
                         </button>
                     </div>
                     <div class="card-body">
-                        <div class="row g-2">
+                        <!-- Row 1: Partition params -->
+                        <div class="row g-2 pb-3 mb-3" style="border-bottom: 1px solid #dee2e6">
                             <div class="col-md-3">
-                                <label class="form-label small text-muted">Partition By</label>
-                                <input class="form-control form-control-sm" :value="spec.partition_by" disabled>
+                                <label class="form-label small fw-semibold text-start d-block">Partition By</label>
+                                <template x-if="spec._editable">
+                                    <select class="form-select form-select-sm"
+                                            x-model="spec.partition_by"
+                                            @change="syncStore()">
+                                        <option :value="null">flat (no partition)</option>
+                                        <template x-for="col in unusedPartitionColumns(idx)" :key="col">
+                                            <option :value="col" x-text="col"></option>
+                                        </template>
+                                    </select>
+                                </template>
+                                <template x-if="!spec._editable">
+                                    <input class="form-control form-control-sm" :value="spec.partition_by || 'flat'" disabled>
+                                </template>
                             </div>
                             <div class="col-md-3">
-                                <label class="form-label small text-muted">Strategy</label>
-                                <input class="form-control form-control-sm" :value="spec.partition_strategy" disabled>
+                                <label class="form-label small fw-semibold text-start d-block">Strategy</label>
+                                <select class="form-select form-select-sm"
+                                        x-model="spec.partition_strategy"
+                                        @change="syncStore()">
+                                    <option value="percentile_range">percentile_range</option>
+                                    <option value="uniform_range">uniform_range</option>
+                                    <option value="hash">hash</option>
+                                </select>
                             </div>
                             <div class="col-md-3">
-                                <label class="form-label small text-muted">N Partitions</label>
+                                <label class="form-label small fw-semibold text-start d-block">N Partitions</label>
                                 <input type="number" class="form-control form-control-sm"
-                                       x-model.number="spec.n_partitions" min="1">
-                                <div class="form-text">Leave or override</div>
+                                       x-model.number="spec.n_partitions" min="1"
+                                       placeholder="auto"
+                                       @change="syncStore()">
                             </div>
                             <div class="col-md-3">
-                                <label class="form-label small text-muted">Target File Size (MB)</label>
+                                <label class="form-label small fw-semibold text-start d-block">Target File Size (MB)</label>
                                 <input type="number" class="form-control form-control-sm"
                                        x-model.number="spec.target_file_size_mb"
                                        :placeholder="$store.dlWizard.state.targetPartitionSizeMb + ' (global)'"
-                                       min="1">
-                                <div class="form-text">Override per-spec</div>
+                                       min="1"
+                                       @change="syncStore()">
                             </div>
-                            <div class="col-md-4">
-                                <label class="form-label small text-muted">Z-Order Columns</label>
-                                <input class="form-control form-control-sm" :value="(spec.zorder_columns || []).join(', ')" disabled>
+                        </div>
+                        <!-- Row 2: Z-order columns -->
+                        <div class="pb-3 mb-3" style="border-bottom: 1px solid #dee2e6">
+                            <label class="form-label small fw-semibold text-start d-block">Z-Order Columns <span class="fw-normal text-muted">(order matters)</span></label>
+                            <div class="d-flex flex-wrap gap-1 mb-1">
+                                <template x-for="(col, colIdx) in (spec.zorder_columns || [])" :key="col">
+                                    <span class="badge bg-primary d-inline-flex align-items-center gap-1">
+                                        <button type="button" class="btn btn-link btn-sm text-white p-0"
+                                                :disabled="colIdx === 0"
+                                                @click="moveZorderColumn(idx, colIdx, -1)">
+                                            <i class="fas fa-chevron-left" style="font-size: 0.6rem"></i>
+                                        </button>
+                                        <span x-text="col"></span>
+                                        <button type="button" class="btn btn-link btn-sm text-white p-0"
+                                                :disabled="colIdx === spec.zorder_columns.length - 1"
+                                                @click="moveZorderColumn(idx, colIdx, 1)">
+                                            <i class="fas fa-chevron-right" style="font-size: 0.6rem"></i>
+                                        </button>
+                                        <button type="button" class="btn-close btn-close-white ms-1" style="font-size: 0.5rem"
+                                                @click="removeZorderColumn(idx, colIdx)"></button>
+                                    </span>
+                                </template>
                             </div>
-                            <div class="col-md-4">
-                                <label class="form-label small text-muted">Bloom Filter Columns</label>
-                                <input class="form-control form-control-sm" :value="(spec.bloom_filter_columns || []).join(', ')" disabled>
+                            <select class="form-select form-select-sm" style="max-width: 300px"
+                                    @change="addZorderColumn(idx, $event.target.value); $event.target.value = ''">
+                                <option value="">+ Add column...</option>
+                                <template x-for="col in availableColumns.filter(c => !(spec.zorder_columns || []).includes(c))" :key="col">
+                                    <option :value="col" x-text="col"></option>
+                                </template>
+                            </select>
+                        </div>
+                        <!-- Row 3: Bloom filter columns + FPP -->
+                        <div class="d-flex gap-4 align-items-start">
+                            <div>
+                                <label class="form-label small fw-semibold text-start d-block">Bloom Filter Columns</label>
+                                <div class="d-flex flex-wrap gap-1 mb-1">
+                                    <template x-for="col in (spec.bloom_filter_columns || [])" :key="col">
+                                        <span class="badge bg-secondary d-inline-flex align-items-center gap-1">
+                                            <span x-text="col"></span>
+                                            <button type="button" class="btn-close btn-close-white ms-1" style="font-size: 0.5rem"
+                                                    @click="toggleBloomColumn(idx, col)"></button>
+                                        </span>
+                                    </template>
+                                </div>
+                                <select class="form-select form-select-sm" style="width: 200px"
+                                        @change="toggleBloomColumn(idx, $event.target.value); $event.target.value = ''">
+                                    <option value="">+ Add column...</option>
+                                    <template x-for="col in availableColumns.filter(c => !(spec.bloom_filter_columns || []).includes(c))" :key="col">
+                                        <option :value="col" x-text="col"></option>
+                                    </template>
+                                </select>
                             </div>
-                            <div class="col-md-4" x-show="spec.source_geometry_column">
-                                <label class="form-label small text-muted">Geometry Column</label>
-                                <input class="form-control form-control-sm" :value="spec.source_geometry_column" disabled>
+                            <div style="width: 140px">
+                                <label class="form-label small fw-semibold text-start d-block">Bloom Filter FPP</label>
+                                <input type="number" class="form-control form-control-sm"
+                                       x-model.number="spec.bloom_filter_fpp"
+                                       :placeholder="$store.dlWizard.state.bloomFilterFpp + ' (global)'"
+                                       step="0.0001" min="0.0001" max="1"
+                                       @change="syncStore()">
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
         </template>
+    </div>
+
+    <!-- Add Spec -->
+    <div class="mt-3">
+        <button class="btn btn-sm btn-outline-success" @click="addSpec()">
+            <i class="fas fa-plus me-1"></i>Add Spec
+        </button>
     </div>
 
     <!-- Actions -->

--- a/templates/deltalake/step2.html
+++ b/templates/deltalake/step2.html
@@ -53,7 +53,7 @@
                                         @change="onPartitionChange(idx, $event.target.value)">
                                     <option value="" :selected="!spec.partition_by">flat (no partition)</option>
                                     <template x-for="col in partitionColumns(spec)" :key="col">
-                                        <option :value="col" x-text="col"
+                                        <option :value="col" x-text="columnDisplayName(col)"
                                                 :selected="col === (spec.source_geometry_column || spec.partition_by)"></option>
                                     </template>
                                 </select>
@@ -105,7 +105,7 @@
                                                 @click="moveZorderColumn(idx, colIdx, -1)">
                                             <i class="fas fa-chevron-left" style="font-size: 0.6rem"></i>
                                         </button>
-                                        <span x-text="col"></span>
+                                        <span x-text="zorderBadgeLabel(col)"></span>
                                         <button type="button" class="btn btn-link btn-sm text-white p-0"
                                                 :disabled="colIdx === spec.zorder_columns.length - 1"
                                                 @click="moveZorderColumn(idx, colIdx, 1)">
@@ -119,10 +119,16 @@
                             <select class="form-select form-select-sm" style="max-width: 300px"
                                     @change="addZorderColumn(idx, $event.target.value); $event.target.value = ''">
                                 <option value="">+ Add column...</option>
-                                <template x-for="col in availableColumns.filter(c => !(spec.zorder_columns || []).includes(c))" :key="col">
-                                    <option :value="col" x-text="col"></option>
+                                <template x-for="col in zorderSelectableColumns(spec)" :key="col">
+                                    <option :value="col" x-text="columnDisplayName(col)"></option>
                                 </template>
                             </select>
+                            <template x-if="(spec.zorder_columns || []).some(c => isMortonZorderCol(c))">
+                                <small class="form-text text-info">
+                                    <i class="fas fa-info-circle me-1"></i>
+                                    Spatial columns (marked *) are morton-encoded for efficient spatial ordering.
+                                </small>
+                            </template>
                         </div>
                         <!-- Row 3: Bloom filter columns + FPP -->
                         <div class="d-flex gap-4 align-items-start">

--- a/templates/deltalake/step2.html
+++ b/templates/deltalake/step2.html
@@ -62,7 +62,6 @@
                                         <i class="fas fa-info-circle me-1"></i>
                                         Spatial column — will be morton-encoded →
                                         <code x-text="spec.partition_by"></code>
-                                        (uniform_range)
                                     </small>
                                 </template>
                             </div>

--- a/templates/deltalake/step2.html
+++ b/templates/deltalake/step2.html
@@ -50,11 +50,11 @@
                             <div class="col-md-3">
                                 <label class="form-label small fw-semibold text-start d-block">Partition By</label>
                                 <select class="form-select form-select-sm"
-                                        :value="spec.source_geometry_column || spec.partition_by || ''"
                                         @change="onPartitionChange(idx, $event.target.value)">
-                                    <option value="">flat (no partition)</option>
+                                    <option value="" :selected="!spec.partition_by">flat (no partition)</option>
                                     <template x-for="col in partitionColumns(spec)" :key="col">
-                                        <option :value="col" x-text="col"></option>
+                                        <option :value="col" x-text="col"
+                                                :selected="col === (spec.source_geometry_column || spec.partition_by)"></option>
                                     </template>
                                 </select>
                                 <template x-if="spec.source_geometry_column">

--- a/templates/deltalake/step2.html
+++ b/templates/deltalake/step2.html
@@ -1,0 +1,90 @@
+<div class="card-body" x-data="deltalakeStep2">
+    <h4 class="card-title mb-4">
+        <i class="fas fa-layer-group me-2"></i>Review Output Specs
+    </h4>
+
+    <!-- Table metadata -->
+    <div class="alert alert-info d-flex gap-4 mb-4">
+        <span><strong>Row count:</strong> <span x-text="rowCount?.toLocaleString()"></span></span>
+        <span><strong>Est. bytes/row:</strong> <span x-text="bytesPerRow"></span></span>
+    </div>
+
+    <!-- Spec cards -->
+    <div class="row g-3">
+        <template x-for="(spec, idx) in specs" :key="idx">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <strong x-text="`Spec: ${spec.partition_by || 'flat'}`"></strong>
+                        <button class="btn btn-sm btn-outline-danger"
+                                :disabled="specs.length <= 1"
+                                @click="removeSpec(idx)">
+                            <i class="fas fa-trash"></i>
+                        </button>
+                    </div>
+                    <div class="card-body">
+                        <div class="row g-2">
+                            <div class="col-md-3">
+                                <label class="form-label small text-muted">Partition By</label>
+                                <input class="form-control form-control-sm" :value="spec.partition_by" disabled>
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label small text-muted">Strategy</label>
+                                <input class="form-control form-control-sm" :value="spec.partition_strategy" disabled>
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label small text-muted">N Partitions</label>
+                                <input type="number" class="form-control form-control-sm"
+                                       x-model.number="spec.n_partitions" min="1">
+                                <div class="form-text">Leave or override</div>
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label small text-muted">Target File Size (MB)</label>
+                                <input type="number" class="form-control form-control-sm"
+                                       x-model.number="spec.target_file_size_mb"
+                                       :placeholder="$store.dlWizard.state.targetPartitionSizeMb + ' (global)'"
+                                       min="1">
+                                <div class="form-text">Override per-spec</div>
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label small text-muted">Z-Order Columns</label>
+                                <input class="form-control form-control-sm" :value="(spec.zorder_columns || []).join(', ')" disabled>
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label small text-muted">Bloom Filter Columns</label>
+                                <input class="form-control form-control-sm" :value="(spec.bloom_filter_columns || []).join(', ')" disabled>
+                            </div>
+                            <div class="col-md-4" x-show="spec.source_geometry_column">
+                                <label class="form-label small text-muted">Geometry Column</label>
+                                <input class="form-control form-control-sm" :value="spec.source_geometry_column" disabled>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </template>
+    </div>
+
+    <!-- Actions -->
+    <div class="mt-4 d-flex gap-3">
+        <button class="btn btn-outline-primary" @click="recalculate()" :disabled="recalculating">
+            <template x-if="!recalculating">
+                <span><i class="fas fa-calculator me-2"></i>Recalculate Partitions</span>
+            </template>
+            <template x-if="recalculating">
+                <span><i class="fas fa-spinner fa-spin me-2"></i>Recalculating...</span>
+            </template>
+        </button>
+
+        <button class="btn btn-outline-secondary" @click="$store.dlWizard.prev()">
+            <i class="fas fa-arrow-left me-2"></i>Back
+        </button>
+
+        <button class="btn btn-primary" @click="$store.dlWizard.next()">
+            Next <i class="fas fa-arrow-right ms-2"></i>
+        </button>
+    </div>
+
+    <!-- Error display -->
+    <div x-show="error" class="alert alert-danger mt-3" x-text="error"></div>
+</div>

--- a/templates/deltalake/step3.html
+++ b/templates/deltalake/step3.html
@@ -1,0 +1,70 @@
+<div class="card-body" x-data="deltalakeStep3">
+    <h4 class="card-title mb-4">
+        <i class="fas fa-rocket me-2"></i>Confirm & Launch Export
+    </h4>
+
+    <!-- Summary -->
+    <table class="table table-bordered">
+        <tbody>
+            <tr>
+                <th>Datastack</th>
+                <td x-text="$store.dlWizard.state.datastack"></td>
+            </tr>
+            <tr>
+                <th>Version</th>
+                <td x-text="'v' + $store.dlWizard.state.version"></td>
+            </tr>
+            <tr>
+                <th>Table</th>
+                <td x-text="$store.dlWizard.state.tableName"></td>
+            </tr>
+            <tr>
+                <th>Row Count</th>
+                <td x-text="$store.dlWizard.state.rowCount?.toLocaleString()"></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h5 class="mt-4 mb-3">Output Specs</h5>
+    <table class="table table-sm table-striped">
+        <thead>
+            <tr>
+                <th>Partition By</th>
+                <th>Strategy</th>
+                <th>N Partitions</th>
+                <th>File Size (MB)</th>
+                <th>Destination</th>
+            </tr>
+        </thead>
+        <tbody>
+            <template x-for="spec in $store.dlWizard.state.specs" :key="spec.partition_by">
+                <tr>
+                    <td x-text="spec.partition_by || 'flat'"></td>
+                    <td x-text="spec.partition_strategy"></td>
+                    <td x-text="spec.n_partitions"></td>
+                    <td x-text="spec.target_file_size_mb || $store.dlWizard.state.targetPartitionSizeMb"></td>
+                    <td class="text-muted small" x-text="outputUri(spec)"></td>
+                </tr>
+            </template>
+        </tbody>
+    </table>
+
+    <!-- Actions -->
+    <div class="mt-4 d-flex gap-3">
+        <button class="btn btn-outline-secondary" @click="$store.dlWizard.prev()">
+            <i class="fas fa-arrow-left me-2"></i>Back
+        </button>
+
+        <button class="btn btn-success btn-lg" @click="launchExport()" :disabled="launching">
+            <template x-if="!launching">
+                <span><i class="fas fa-play me-2"></i>Launch Export</span>
+            </template>
+            <template x-if="launching">
+                <span><i class="fas fa-spinner fa-spin me-2"></i>Launching...</span>
+            </template>
+        </button>
+    </div>
+
+    <!-- Error display -->
+    <div x-show="error" class="alert alert-danger mt-3" x-text="error"></div>
+</div>

--- a/templates/deltalake/step3.html
+++ b/templates/deltalake/step3.html
@@ -37,7 +37,7 @@
             </tr>
         </thead>
         <tbody>
-            <template x-for="spec in $store.dlWizard.state.specs" :key="spec.partition_by">
+            <template x-for="(spec, index) in $store.dlWizard.state.specs" :key="index">
                 <tr>
                     <td x-text="spec.partition_by || 'flat'"></td>
                     <td x-text="spec.partition_strategy"></td>
@@ -55,7 +55,7 @@
             <i class="fas fa-arrow-left me-2"></i>Back
         </button>
 
-        <button class="btn btn-success btn-lg" @click="launchExport()" :disabled="launching">
+        <button class="btn btn-success btn-lg" @click="launchExport()" :disabled="launching || existingExports.length > 0">
             <template x-if="!launching">
                 <span><i class="fas fa-play me-2"></i>Launch Export</span>
             </template>
@@ -63,6 +63,21 @@
                 <span><i class="fas fa-spinner fa-spin me-2"></i>Launching...</span>
             </template>
         </button>
+    </div>
+
+    <!-- Existence check warning -->
+    <div x-show="existingExports.length > 0" class="alert alert-danger mt-3 mb-0">
+        <strong><i class="fas fa-exclamation-triangle me-1"></i>Cannot launch — existing exports found</strong>
+        <p class="mb-1 mt-2">Delta Lake data already exists at the following locations:</p>
+        <ul class="mb-1">
+            <template x-for="spec in existingExports" :key="spec.uri">
+                <li>
+                    <code x-text="spec.uri"></code>
+                    <span class="text-muted" x-text="`(${spec.row_count.toLocaleString()} rows)`"></span>
+                </li>
+            </template>
+        </ul>
+        <small class="text-muted">Delete the existing data or change spec names before re-exporting.</small>
     </div>
 
     <!-- Error display -->

--- a/templates/deltalake_wizard.html
+++ b/templates/deltalake_wizard.html
@@ -1,0 +1,135 @@
+{% extends "base.html" %}
+{% block title %}Delta Lake Export - Step {{ current_step }}{% endblock %}
+
+{% block html_head %}
+<script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+<script src="{{ url_for('static', filename='js/deltalakeWizardStore.js') }}"></script>
+<script src="{{ url_for('static', filename='js/deltalakeStep1.js') }}"></script>
+<script src="{{ url_for('static', filename='js/deltalakeStep2.js') }}"></script>
+<script src="{{ url_for('static', filename='js/deltalakeStep3.js') }}"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+<style>
+    .wizard-steps {
+        position: relative;
+        padding: 0 2rem;
+    }
+
+    .wizard-progress {
+        height: 3px;
+        background-color: #e9ecef;
+        position: relative;
+        margin: 2rem 0;
+    }
+
+    .wizard-progress-bar {
+        position: absolute;
+        height: 100%;
+        background-color: #198754;
+        transition: width 0.3s ease;
+    }
+
+    .wizard-step-list {
+        display: flex;
+        justify-content: space-between;
+        position: absolute;
+        width: 100%;
+        top: 50%;
+        transform: translateY(-50%);
+    }
+
+    .wizard-step {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+        width: 120px;
+        margin-top: -2rem;
+    }
+
+    .step-circle {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        background: white;
+        border: 2px solid #dee2e6;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 500;
+        transition: all 0.2s ease;
+        z-index: 1;
+    }
+
+    .step-circle.active {
+        background: #0d6efd;
+        border-color: #0d6efd;
+        color: white;
+        box-shadow: 0 0 0 4px rgba(13, 110, 253, 0.25);
+    }
+
+    .step-circle.completed {
+        background: #198754;
+        border-color: #198754;
+        color: white;
+    }
+
+    .step-label {
+        font-size: 0.875rem;
+        color: #6c757d;
+        text-align: center;
+        margin-top: 0.5rem;
+        font-weight: 500;
+    }
+
+    .step-label.active {
+        color: #0d6efd;
+    }
+
+    .step-label.completed {
+        color: #198754;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="wizard-container" x-data>
+    <!-- Step Indicator -->
+    <div class="wizard-steps">
+        <div class="wizard-progress">
+            <div class="wizard-progress-bar"
+                 :style="`width: ${(($store.dlWizard.state.currentStep - 1) / ({{ total_steps }} - 1)) * 100}%`">
+            </div>
+            <div class="wizard-step-list">
+                {% for step_num in range(1, total_steps + 1) %}
+                <div class="wizard-step">
+                    <div class="step-circle"
+                         :class="{
+                             'active': $store.dlWizard.state.currentStep === {{ step_num }},
+                             'completed': $store.dlWizard.state.stepStatus[{{ step_num }}].completed
+                         }">
+                        <template x-if="$store.dlWizard.state.stepStatus[{{ step_num }}].completed">
+                            <i class="fas fa-check"></i>
+                        </template>
+                        <template x-if="!$store.dlWizard.state.stepStatus[{{ step_num }}].completed">
+                            <span>{{ step_num }}</span>
+                        </template>
+                    </div>
+                    <div class="step-label"
+                         :class="{
+                             'active': $store.dlWizard.state.currentStep === {{ step_num }},
+                             'completed': $store.dlWizard.state.stepStatus[{{ step_num }}].completed
+                         }">
+                        <span>{{ ["Select Table", "Review Specs", "Confirm"][step_num - 1] }}</span>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <div class="card mt-5">
+        {% include step_template %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/deltalake_wizard.html
+++ b/templates/deltalake_wizard.html
@@ -7,7 +7,6 @@
 <script src="{{ url_for('static', filename='js/deltalakeStep1.js') }}"></script>
 <script src="{{ url_for('static', filename='js/deltalakeStep2.js') }}"></script>
 <script src="{{ url_for('static', filename='js/deltalakeStep3.js') }}"></script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
 <style>
     .wizard-steps {
         position: relative;

--- a/tests/test_deltalake_export.py
+++ b/tests/test_deltalake_export.py
@@ -1198,3 +1198,137 @@ class TestDecodeGeometryColumnsMemory:
         assert result["pt_x"].to_list() == [10, None, 40]
         assert result["pt_y"].to_list() == [20, None, 50]
         assert result["pt_z"].to_list() == [30, None, 60]
+
+
+# ---------------------------------------------------------------------------
+# Tests for deltalake-export-ui features
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaLakeOutputSpecTargetFileSize:
+    """Test the target_file_size_mb field on DeltaLakeOutputSpec."""
+
+    def test_default_is_none(self):
+        spec = DeltaLakeOutputSpec()
+        assert spec.target_file_size_mb is None
+
+    def test_can_set_value(self):
+        spec = DeltaLakeOutputSpec(target_file_size_mb=128)
+        assert spec.target_file_size_mb == 128
+
+    def test_resolve_n_partitions_with_per_spec_override(self):
+        """Per-spec target_file_size_mb should affect partition count."""
+        row_count = 1_000_000
+        bytes_per_row = 200
+        # 200 bytes * 1M rows = 200MB total → with 128MB target = 2 partitions
+        n = resolve_n_partitions(
+            "auto", row_count, target_file_size_mb=128, bytes_per_row=bytes_per_row
+        )
+        assert n == 2
+
+        # Same data with 256MB target = 1 partition
+        n = resolve_n_partitions(
+            "auto", row_count, target_file_size_mb=256, bytes_per_row=bytes_per_row
+        )
+        assert n == 1
+
+
+class TestRecalculateLogic:
+    """Test the pure-computation recalculate logic."""
+
+    def test_auto_resolves(self):
+        n = resolve_n_partitions(
+            "auto", 10_000_000, target_file_size_mb=256, bytes_per_row=200
+        )
+        # 10M * 200 = 2GB total, 2GB / 256MB = 8 partitions
+        assert n == 8
+
+    def test_explicit_passthrough(self):
+        n = resolve_n_partitions(
+            50, 10_000_000, target_file_size_mb=256, bytes_per_row=200
+        )
+        assert n == 50
+
+
+class TestProgressPayloadFields:
+    """Test that set_deltalake_export_status accepts phase and error."""
+
+    @patch("materializationengine.workflows.deltalake_export._get_redis_client")
+    def test_status_includes_phase_and_error(self, mock_redis_client):
+        import json
+
+        from materializationengine.workflows.deltalake_export import (
+            set_deltalake_export_status,
+        )
+
+        mock_client = MagicMock()
+        mock_redis_client.return_value = mock_client
+
+        set_deltalake_export_status(
+            "minnie65",
+            943,
+            "synapses",
+            "failed",
+            total_rows=1000,
+            rows_processed=500,
+            phase="streaming",
+            error="Connection reset",
+        )
+
+        # Verify Redis was called with the right payload
+        call_args = mock_client.set.call_args
+        key = call_args[0][0]
+        payload = json.loads(call_args[0][1])
+
+        assert key == "deltalake_export:minnie65:v943:synapses"
+        assert payload["status"] == "failed"
+        assert payload["phase"] == "streaming"
+        assert payload["error"] == "Connection reset"
+        assert payload["percent_complete"] == 50.0
+
+    @patch("materializationengine.workflows.deltalake_export._get_redis_client")
+    def test_append_deltalake_log(self, mock_redis_client):
+        from materializationengine.workflows.deltalake_export import (
+            append_deltalake_log,
+        )
+
+        mock_client = MagicMock()
+        mock_redis_client.return_value = mock_client
+
+        append_deltalake_log("minnie65", 943, "synapses", "Test message")
+
+        mock_client.rpush.assert_called_once()
+        key = mock_client.rpush.call_args[0][0]
+        assert key == "deltalake_log:minnie65:v943:synapses"
+
+        mock_client.ltrim.assert_called_once()
+        mock_client.expire.assert_called_once()
+
+    @patch("materializationengine.workflows.deltalake_export._get_redis_client")
+    def test_get_progress_includes_log_entries(self, mock_redis_client):
+        import json
+
+        from materializationengine.workflows.deltalake_export import (
+            get_deltalake_export_progress,
+        )
+
+        mock_client = MagicMock()
+        mock_redis_client.return_value = mock_client
+
+        progress_data = {
+            "status": "exporting",
+            "phase": "streaming",
+            "rows_processed": 100,
+            "total_rows": 1000,
+            "percent_complete": 10.0,
+            "error": None,
+            "last_updated": "2026-05-05T12:00:00Z",
+        }
+        mock_client.get.return_value = json.dumps(progress_data).encode()
+        mock_client.lrange.return_value = [b"12:00:01 Starting", b"12:00:02 Streaming"]
+
+        result = get_deltalake_export_progress("minnie65", 943, "synapses")
+
+        assert result["log_entries"] == ["12:00:01 Starting", "12:00:02 Streaming"]
+        assert result["phase"] == "streaming"
+        assert result["error"] is None

--- a/tests/test_deltalake_export.py
+++ b/tests/test_deltalake_export.py
@@ -425,6 +425,7 @@ class TestFlushBufferPartitionConsistency:
         """Two flushes with non-overlapping values should land in
         distinct partitions when using shared global breakpoints."""
         spec = DeltaLakeOutputSpec(
+            name="test_percentile",
             partition_by="val",
             partition_strategy="percentile_range",
             n_partitions=4,
@@ -448,6 +449,7 @@ class TestFlushBufferPartitionConsistency:
         """Two flushes with non-overlapping values should land in
         distinct partitions when using linspace-derived breakpoints on the spec."""
         spec = DeltaLakeOutputSpec(
+            name="test_uniform",
             partition_by="val",
             partition_strategy="uniform_range",
             n_partitions=4,
@@ -714,6 +716,7 @@ class TestExportTableToDeltalake:
         mock_stream.return_value = iter([batch1, batch2])
 
         spec = DeltaLakeOutputSpec(
+            name="test_root_id",
             partition_by="root_id",
             partition_strategy="percentile_range",
             n_partitions=2,
@@ -752,6 +755,7 @@ class TestExportTableToDeltalake:
 
         # Explicit spec: hash partition with 2 buckets (not percentile_range)
         spec = DeltaLakeOutputSpec(
+            name="test_hash",
             partition_by="root_id",
             partition_strategy="hash",
             n_partitions=2,
@@ -781,6 +785,7 @@ class TestExportTableToDeltalake:
         mock_stream.return_value = iter([batch1, batch2])
 
         spec = DeltaLakeOutputSpec(
+            name="test_val_percentile",
             partition_by="val",
             partition_strategy="percentile_range",
             n_partitions=2,
@@ -874,6 +879,7 @@ class TestOptimizeDeltalake:
         mock_stream.return_value = iter([batch])
 
         spec = DeltaLakeOutputSpec(
+            name="test_zorder_bloom",
             partition_by="val",
             partition_strategy="hash",
             n_partitions=2,
@@ -888,8 +894,8 @@ class TestOptimizeDeltalake:
             output_uri_base="/tmp/test",
         )
 
-        # Should have opened the DeltaTable at the correct URI
-        MockDeltaTable.assert_called_once_with("/tmp/test/val")
+        # Should have opened the DeltaTable at the correct URI (uses spec.name)
+        MockDeltaTable.assert_called_once_with("/tmp/test/test_zorder_bloom")
         # Should have called z_order (not compact) since zorder_columns is set
         mock_dt.optimize.z_order.assert_called_once()
         mock_dt.vacuum.assert_called_once()
@@ -1209,11 +1215,11 @@ class TestDeltaLakeOutputSpecTargetFileSize:
     """Test the target_file_size_mb field on DeltaLakeOutputSpec."""
 
     def test_default_is_none(self):
-        spec = DeltaLakeOutputSpec()
+        spec = DeltaLakeOutputSpec(name="test_default")
         assert spec.target_file_size_mb is None
 
     def test_can_set_value(self):
-        spec = DeltaLakeOutputSpec(target_file_size_mb=128)
+        spec = DeltaLakeOutputSpec(name="test_size", target_file_size_mb=128)
         assert spec.target_file_size_mb == 128
 
     def test_resolve_n_partitions_with_per_spec_override(self):


### PR DESCRIPTION
This is currently deployed on LTV5

## Select an export
<img width="1205" height="490" alt="Screenshot 2026-05-07 at 12 05 32 PM" src="https://github.com/user-attachments/assets/4416933c-d321-49f7-ac38-788fe3b42210" />

## Select output options for one or more delta lake partition/zorder/filter schemes
<img width="1198" height="693" alt="Screenshot 2026-05-07 at 12 05 46 PM" src="https://github.com/user-attachments/assets/0a7da19d-00f0-4164-8587-b1cec4054f62" />

## Confirmation
<img width="1205" height="723" alt="Screenshot 2026-05-07 at 12 05 53 PM" src="https://github.com/user-attachments/assets/2d94fcf3-05e4-4f67-ae42-7511bb442004" />

## Logging
<img width="1306" height="311" alt="Screenshot 2026-05-07 at 12 05 59 PM" src="https://github.com/user-attachments/assets/406a3b64-21c8-4ed6-a9d4-753d5f8567c9" />

## Progress for long running jobs
<img width="1316" height="506" alt="Screenshot 2026-05-07 at 12 06 29 PM" src="https://github.com/user-attachments/assets/0f178780-c823-4efa-8285-8492d6105ba9" />

## Success
<img width="1305" height="524" alt="Screenshot 2026-05-07 at 12 06 34 PM" src="https://github.com/user-attachments/assets/39ec2e9a-1eb7-4f85-bf8d-e2e28b1208a4" />

## Fail on export that already exists, general error reporting
<img width="1296" height="636" alt="Screenshot 2026-05-07 at 12 05 16 PM" src="https://github.com/user-attachments/assets/26b3be46-a007-46c1-96a4-5a64a1330f20" />
