### PR TITLE
Auto worker shutdown and other fixes

### DIFF
--- a/materializationengine/celery_worker.py
+++ b/materializationengine/celery_worker.py
@@ -1,7 +1,10 @@
 import datetime
 import logging
 import os
+import signal
 import sys
+import threading
+import time
 import warnings
 from typing import Any, Callable, Dict
 
@@ -101,8 +104,102 @@ def create_celery(app=None):
     celery.Task = ContextTask
     if os.environ.get("SLACK_WEBHOOK"):
         celery.Task.on_failure = post_to_slack_on_task_failure
-    
+
+    configure_worker_autoshutdown(app)
+
     return celery
+
+
+def configure_worker_autoshutdown(app):
+    """Let a worker exit after a bounded amount of work so it behaves correctly
+    as a KEDA ScaledJob pod (one pod -> a little work -> exit), instead of
+    running forever like a normal long-lived worker.
+
+    Config (written by the helm chart into the orchestration config.cfg; absent
+    -> feature disabled, so ordinary workers such as producer/consumer/api are
+    unaffected):
+
+      CELERY_WORKER_AUTOSHUTDOWN_ENABLED        master on/off switch
+      CELERY_WORKER_AUTOSHUTDOWN_MAX_TASKS      exit after this many completed tasks
+      CELERY_WORKER_AUTOSHUTDOWN_DELAY_SECONDS  grace period after the last task before
+                                                exiting (lets acks / result writes settle)
+      CELERY_WORKER_IDLE_TIMEOUT_SECONDS        if > 0, exit when no task has started for
+                                                this long -- covers "started but the queue
+                                                was empty". Set small for a near-immediate
+                                                exit on an empty queue (0 = disabled).
+
+    Deliberately task-agnostic (counts any task) so it can be reused on any queue.
+    """
+    if not app.config.get("CELERY_WORKER_AUTOSHUTDOWN_ENABLED", False):
+        return
+
+    from celery.signals import task_postrun, task_prerun, worker_ready
+
+    max_tasks = int(app.config.get("CELERY_WORKER_AUTOSHUTDOWN_MAX_TASKS", 1))
+    shutdown_delay = int(app.config.get("CELERY_WORKER_AUTOSHUTDOWN_DELAY_SECONDS", 2))
+    idle_timeout = int(app.config.get("CELERY_WORKER_IDLE_TIMEOUT_SECONDS", 0))
+
+    state = {"completed": 0, "idle_timer": None, "shutting_down": False}
+    lock = threading.Lock()
+
+    def _shutdown(reason, delay):
+        with lock:
+            if state["shutting_down"]:
+                return
+            state["shutting_down"] = True
+            if state["idle_timer"] is not None:
+                state["idle_timer"].cancel()
+                state["idle_timer"] = None
+        celery_logger.info(f"[autoshutdown] {reason}; exiting in {delay}s")
+
+        def _send_term():
+            if delay > 0:
+                time.sleep(delay)
+            # Warm-shutdown THIS worker only (finish any in-flight task, stop
+            # consuming, exit). Do NOT use app.control.shutdown(): that broadcasts
+            # to every worker on the queue and would kill sibling pods too.
+            os.kill(os.getpid(), signal.SIGTERM)
+
+        threading.Thread(target=_send_term, name="autoshutdown", daemon=True).start()
+
+    def _arm_idle_timer():
+        if idle_timeout <= 0:
+            return
+        with lock:
+            if state["shutting_down"]:
+                return
+            if state["idle_timer"] is not None:
+                state["idle_timer"].cancel()
+            timer = threading.Timer(
+                idle_timeout, _shutdown, args=(f"no task started for {idle_timeout}s", 0)
+            )
+            timer.daemon = True
+            state["idle_timer"] = timer
+            timer.start()
+
+    @worker_ready.connect(weak=False)
+    def _on_worker_ready(**_kwargs):
+        # If the queue was empty at startup (or nothing arrives), exit rather
+        # than linger. A task arriving cancels this via task_prerun.
+        _arm_idle_timer()
+
+    @task_prerun.connect(weak=False)
+    def _on_task_prerun(**_kwargs):
+        with lock:
+            if state["idle_timer"] is not None:
+                state["idle_timer"].cancel()
+                state["idle_timer"] = None
+
+    @task_postrun.connect(weak=False)
+    def _on_task_postrun(**_kwargs):
+        with lock:
+            state["completed"] += 1
+            completed = state["completed"]
+        if completed >= max_tasks:
+            _shutdown(f"completed {completed}/{max_tasks} task(s)", shutdown_delay)
+        else:
+            # More tasks allowed on this pod; wait for the next, but don't linger.
+            _arm_idle_timer()
 
 
 @after_setup_logger.connect

--- a/materializationengine/shared_tasks.py
+++ b/materializationengine/shared_tasks.py
@@ -488,9 +488,21 @@ def check_if_task_is_running(task_name: str, worker_name_prefix: str) -> bool:
     inspector = celery.control.inspect()
     active_tasks_dict = inspector.active()
 
+    # inspect().active() returns None when no worker replies to the broadcast
+    # (e.g. the target workers are scaled to zero under KEDA). No live worker
+    # means nothing is running. NOTE: this only reflects tasks a worker is
+    # actively executing -- a task sitting in the broker queue or on a
+    # cold-starting pod is invisible here, so callers that must not race with a
+    # queued task should check the LockedTask redis lock instead.
+    if not active_tasks_dict:
+        return False
+
     workflow_active_tasks = next(
-        v for k, v in active_tasks_dict.items() if worker_name_prefix in k
+        (v for k, v in active_tasks_dict.items() if worker_name_prefix in k),
+        None,
     )
+    if not workflow_active_tasks:
+        return False
 
     for active_task in workflow_active_tasks:
         if task_name in active_task.values():

--- a/materializationengine/task.py
+++ b/materializationengine/task.py
@@ -1,4 +1,5 @@
 import json
+import threading
 from hashlib import md5
 
 import redis
@@ -146,3 +147,82 @@ class LockedTask(Task):
 
     def on_success(self, retval, task_id, args, kwargs):
         self.release_lock(task_args=args, task_kwargs=kwargs)
+
+
+# Lua: refresh TTL only if we still own the lease (avoids extending a lease that
+# expired and was re-acquired by another run).
+_LEASE_REFRESH_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] "
+    "then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end"
+)
+# Lua: delete only if we still own the lease (owner-checked release).
+_LEASE_RELEASE_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] "
+    "then return redis.call('del', KEYS[1]) else return 0 end"
+)
+
+
+class RedisLease:
+    """A heartbeat-refreshed Redis lock that guards a long-running task's
+    *execution* -- unlike :class:`LockedTask`, which locks at ``apply_async``
+    (enqueue) time and so cannot stop a broker *redelivery* that re-runs the same
+    message without re-enqueuing.
+
+    Acquire once at the top of a task; a daemon thread refreshes the TTL every
+    ``refresh_interval`` seconds while the task runs, so an arbitrarily long
+    workflow stays locked. If the pod dies uncontrolled (SIGKILL, node loss) the
+    heartbeat stops and the lease self-expires within ~``lease_ttl`` seconds, so
+    a legitimate future run isn't blocked for long. Ownership is tracked by a
+    per-execution token, so even a same-``task_id`` redelivery running
+    concurrently is excluded (it does not own the token).
+
+    Example
+    -------
+    >>> lease = RedisLease(f"RUN_COMPLETE_WORKFLOW_LOCK:{datastack}")
+    >>> if not lease.acquire():
+    ...     return False  # another run holds it -> skip this duplicate
+    >>> try:
+    ...     do_work()
+    ... finally:
+    ...     lease.release()
+    """
+
+    def __init__(self, key: str, lease_ttl: int = 600, refresh_interval: int = 120):
+        self.key = key
+        self.token = uuid()
+        self.lease_ttl = int(lease_ttl)
+        self.refresh_interval = int(refresh_interval)
+        self._stop = threading.Event()
+        self._thread = None
+
+    def acquire(self) -> bool:
+        acquired = REDIS_CLIENT.set(self.key, self.token, nx=True, ex=self.lease_ttl)
+        if acquired:
+            self._thread = threading.Thread(
+                target=self._heartbeat, name=f"redis-lease-{self.key}", daemon=True
+            )
+            self._thread.start()
+        return bool(acquired)
+
+    def _heartbeat(self):
+        refresh = REDIS_CLIENT.register_script(_LEASE_REFRESH_LUA)
+        while not self._stop.wait(self.refresh_interval):
+            try:
+                refresh(keys=[self.key], args=[self.token, self.lease_ttl * 1000])
+            except Exception as e:  # never let a transient redis error kill the task
+                celery_logger.warning(f"RedisLease heartbeat failed for {self.key}: {e}")
+
+    def release(self):
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        try:
+            REDIS_CLIENT.register_script(_LEASE_RELEASE_LUA)(
+                keys=[self.key], args=[self.token]
+            )
+        except Exception as e:
+            celery_logger.warning(f"RedisLease release failed for {self.key}: {e}")
+
+    @property
+    def holder(self):
+        return REDIS_CLIENT.get(self.key)

--- a/materializationengine/workflows/complete_workflow.py
+++ b/materializationengine/workflows/complete_workflow.py
@@ -23,7 +23,7 @@ from materializationengine.workflows.ingest_new_annotations import (
     ingest_new_annotations_workflow,
     find_missing_root_ids_workflow
 )
-from materializationengine.task import LockedTask
+from materializationengine.task import LockedTask, RedisLease
 from materializationengine.workflows.update_root_ids import (
     update_root_ids_workflow,
 )
@@ -54,6 +54,37 @@ def run_complete_workflow(
         datastack_info (dict): [description]
         days_to_expire (int, optional): [description]. Defaults to 5.
     """
+    # Guard the *execution* against duplicates for this datastack. The task is
+    # acks_late=False and blocks in monitor_workflow_state for the whole workflow
+    # (hours); broker redeliveries (and any duplicate enqueue) re-run the SAME
+    # message on fresh KEDA orchestration pods, so without this every duplicate
+    # would create another database version and update root ids concurrently --
+    # which corrupts the copy. A heartbeat-refreshed lease keyed by datastack
+    # lets one run proceed and turns every concurrent duplicate into a no-op.
+    datastack = datastack_info["datastack"]
+    lease = RedisLease(f"RUN_COMPLETE_WORKFLOW_LOCK:{datastack}")
+    if not lease.acquire():
+        celery_logger.warning(
+            f"run_complete_workflow for {datastack} is already running "
+            f"(lease held by {lease.holder!r}); skipping duplicate execution "
+            f"{self.request.id}."
+        )
+        return False
+    try:
+        return _run_complete_workflow(
+            self, datastack_info, days_to_expire, merge_tables, **kwargs
+        )
+    finally:
+        lease.release()
+
+
+def _run_complete_workflow(
+    self,
+    datastack_info: dict,
+    days_to_expire: int = 5,
+    merge_tables: bool = True,
+    **kwargs,
+):
     materialization_time_stamp = datetime.datetime.utcnow()
 
     new_version_number = create_new_version(

--- a/materializationengine/workflows/periodic_materialization.py
+++ b/materializationengine/workflows/periodic_materialization.py
@@ -10,17 +10,42 @@ from materializationengine.blueprints.materialize.api import get_datastack_info
 from materializationengine.celery_init import celery
 from materializationengine.database import db_manager
 from dynamicannotationdb.models import AnalysisVersion
-from materializationengine.shared_tasks import check_if_task_is_running
+from materializationengine.task import REDIS_CLIENT, argument_signature
 from materializationengine.utils import get_config_param
 from materializationengine.workflows.complete_workflow import run_complete_workflow
 
 celery_logger = get_task_logger(__name__)
 
 
-def process_datastack(datastack, days_to_expire, merge_tables):
+def update_database_workflow_locked(datastack: str, datastack_info: dict) -> bool:
+    """Return True if an update_database_workflow for this datastack is already
+    queued or running.
+
+    This checks the Redis lock that ``LockedTask`` sets at *enqueue* time (see
+    ``materializationengine.task``), not live worker state. That matters under
+    KEDA scale-to-zero: the lock is present the moment the workflow is queued,
+    so we detect it even while the worker pod is still cold-starting and before
+    any task shows up in ``celery.control.inspect().active()``.
+
+    Note: this reconstructs the lock id for the *periodic* enqueue path
+    (``run_periodic_database_update``, which passes ``kwargs={"Datastack": ...}``).
+    An update triggered manually via the admin API mutates ``datastack_info``
+    before enqueuing and therefore locks under a different id; that path is not
+    detected here.
+    """
+    from materializationengine.workflows.update_database_workflow import (
+        update_database_workflow,
+    )
+
+    lock_id = argument_signature(
+        update_database_workflow.name, [datastack_info], {"Datastack": datastack}
+    )
+    return REDIS_CLIENT.get(lock_id) is not None
+
+
+def process_datastack(datastack, datastack_info, days_to_expire, merge_tables):
     celery_logger.info(f"Start periodic materialization job for {datastack}")
 
-    datastack_info = get_datastack_info(datastack)
     aligned_volume = datastack_info["aligned_volume"]["name"]
 
     with db_manager.session_scope(aligned_volume) as session:
@@ -57,12 +82,6 @@ def run_periodic_materialization(
     4. Merge annotation and segmentation tables together
     5. Drop non-materialized tables
     """
-    is_update_roots_running = check_if_task_is_running(
-        "workflow:update_database_workflow", "worker.workflow"
-    )
-    if is_update_roots_running:
-        return "Update Roots Workflow is running, delaying materialization until update roots is complete."
-
     if datastack:
         datastacks = [datastack]
 
@@ -74,7 +93,16 @@ def run_periodic_materialization(
 
     for datastack in datastacks:
         try:
-            is_running = process_datastack(datastack, days_to_expire, merge_tables)
+            datastack_info = get_datastack_info(datastack)
+            if update_database_workflow_locked(datastack, datastack_info):
+                celery_logger.error(
+                    f"Update roots workflow is queued or running for {datastack}; "
+                    "delaying materialization until it completes."
+                )
+                continue
+            is_running = process_datastack(
+                datastack, datastack_info, days_to_expire, merge_tables
+            )
             if not is_running:
                 celery_logger.error(f"Materialization workflow for {datastack} is not running: {is_running}")
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "flask-accepts",
     "geoalchemy2>=0.9.2",
     "alembic",
-    "celery>=5.2.3",
+    "celery[redis]>=5.2.3",
     "cachetools",
     "gevent",
     "gcsfs>=0.8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -395,6 +395,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/af/0dcccc7fdcdf170f9a1585e5e96b6fb0ba1749ef6be8c89a6202284759bd/celery-5.5.3-py3-none-any.whl", hash = "sha256:0b5761a07057acee94694464ca482416b959568904c9dfa41ce8413a7d65d525", size = 438775, upload-time = "2025-06-01T11:08:09.94Z" },
 ]
 
+[package.optional-dependencies]
+redis = [
+    { name = "kombu", extra = ["redis"] },
+]
+
 [[package]]
 name = "certifi"
 version = "2025.6.15"
@@ -1596,6 +1601,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/70/a07dcf4f62598c8ad579df241af55ced65bed76e42e45d3c368a6d82dbc1/kombu-5.5.4-py3-none-any.whl", hash = "sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8", size = 210034, upload-time = "2025-06-01T10:19:20.436Z" },
 ]
 
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
+]
+
 [[package]]
 name = "kvdbclient"
 version = "0.5.0"
@@ -1722,14 +1732,14 @@ wheels = [
 
 [[package]]
 name = "materializationengine"
-version = "5.23.0"
+version = "5.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-postgresql" },
     { name = "alembic" },
     { name = "cachetools" },
     { name = "caveclient" },
-    { name = "celery" },
+    { name = "celery", extra = ["redis"] },
     { name = "cloud-files" },
     { name = "cloud-volume" },
     { name = "cryptography" },
@@ -1795,7 +1805,7 @@ requires-dist = [
     { name = "alembic" },
     { name = "cachetools" },
     { name = "caveclient", specifier = ">=7.7.0" },
-    { name = "celery", specifier = ">=5.2.3" },
+    { name = "celery", extras = ["redis"], specifier = ">=5.2.3" },
     { name = "cloud-files", specifier = ">=4.6.1" },
     { name = "cloud-volume", specifier = ">=8.5.4" },
     { name = "cryptography", specifier = ">=44.0.2" },
@@ -2674,15 +2684,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyjwt"
-version = "2.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/68/ce067f09fca4abeca8771fe667d89cc347d1e99da3e093112ac329c6020e/pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c", size = 78825, upload-time = "2024-08-01T15:01:08.445Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850", size = 22344, upload-time = "2024-08-01T15:01:06.481Z" },
-]
-
-[[package]]
 name = "pymdown-extensions"
 version = "10.16"
 source = { registry = "https://pypi.org/simple" }
@@ -2925,14 +2926,11 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "5.3.0"
+version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyjwt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/71/dd/2b37032f4119dff2a2f9bbcaade03221b100ba26051bb96e275de3e5db7a/redis-5.3.0.tar.gz", hash = "sha256:8d69d2dde11a12dc85d0dbf5c45577a5af048e2456f7077d87ad35c1c81c310e", size = 4626288, upload-time = "2025-04-30T14:54:40.634Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/da/d283a37303a995cd36f8b92db85135153dc4f7a8e4441aa827721b442cfb/redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f", size = 4608355, upload-time = "2024-12-06T09:50:41.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/b0/aa601efe12180ba492b02e270554877e68467e66bda5d73e51eaa8ecc78a/redis-5.3.0-py3-none-any.whl", hash = "sha256:f1deeca1ea2ef25c1e4e46b07f4ea1275140526b1feea4c6459c0ec27a10ef83", size = 272836, upload-time = "2025-04-30T14:54:30.744Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/5f/fa26b9b2672cbe30e07d9a5bdf39cf16e3b80b42916757c5f92bca88e4ba/redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4", size = 261502, upload-time = "2024-12-06T09:50:39.656Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds capability of adding redislease on the complete workflow to prevent multiple versions from running at the same time, also downgrades the redis-py to address this issue (https://github.com/celery/celery/pull/6969 and https://github.com/redis/redis-py/pull/1578).  