### PR TITLE
fix deltalake BYTEA error

### DIFF
--- a/materializationengine/blueprints/client/api2.py
+++ b/materializationengine/blueprints/client/api2.py
@@ -3521,7 +3521,10 @@ def get_table_schema(table):
         elif isinstance(column.type, Numeric):
             column_type = "number"
         else:
-            raise ValueError(f"Unsupported column type: {column.type}")
+            raise ValueError(
+                f"Unsupported column type for column "
+                f"'{table.name}.{column.name}': {column.type!r}"
+            )
 
         properties[column.name] = {"type": column_type}
         if format:

--- a/materializationengine/workflows/deltalake_export.py
+++ b/materializationengine/workflows/deltalake_export.py
@@ -15,19 +15,28 @@ import numpy as np
 import polars as pl
 import pyarrow as pa
 import shapely
+
+# Importing geoalchemy2 registers the PostGIS ``geometry`` type in the shared
+# ``PGDialect.ischema_names`` map, so SQLAlchemy's inspector recognizes geometry
+# columns instead of warning "Did not recognize type 'geometry'".
+#
+# Do NOT re-alias ``geometry`` to BYTEA here.  ``PGDialect.ischema_names`` is a
+# single process-global dict shared with geoalchemy2, so mutating it would
+# un-register ``Geometry`` for the whole process -- including the Flask workers
+# that import this module via the Celery ``include`` list.  Client code keys off
+# the reflected type (``isinstance(column.type, Geometry)``) to expand points
+# into x/y/z and to build view jsonschemas, and would silently emit raw WKB and
+# 500 on /views/schemas.  See ViewSchemas in blueprints/client/api2.py.
+#
+# Nothing in this module needs geometry typed as binary: geometry columns are
+# discovered from information_schema by _get_geometry_columns, and the data path
+# is ADBC, which streams geometry as WKB bytes regardless of SQLAlchemy types.
+import geoalchemy2  # noqa: F401
 from celery.utils.log import get_task_logger
 from sqlalchemy import inspect, text
-from sqlalchemy.dialects.postgresql import BYTEA
-
-# Register a minimal geometry type so SQLAlchemy's inspector doesn't warn
-# "Did not recognize type 'geometry'" during reflection.  We decode WKB
-# ourselves — all SQLAlchemy needs to know is that it's binary.
-from sqlalchemy.dialects.postgresql import dialect as _pg_dialect
 from sqlalchemy.engine import Engine
 
 from materializationengine.celery_init import celery
-
-_pg_dialect.ischema_names["geometry"] = BYTEA
 
 celery_logger = get_task_logger(__name__)
 
@@ -237,9 +246,8 @@ def _get_geometry_columns(connection_string: str, name: str) -> list[str]:
     """Return PostGIS geometry column names on *name*, in ordinal order.
 
     Detects columns via ``information_schema.columns.udt_name = 'geometry'``,
-    which works identically for tables, views, and materialized views.  This is
-    necessary because we alias the SQLAlchemy ``geometry`` type to ``BYTEA`` for
-    reflection, so the inspector cannot distinguish geometry from plain bytea.
+    which works identically for tables, views, and materialized views -- unlike
+    SQLAlchemy reflection, which cannot see the columns of a plain view.
     """
     _validate_identifier(name)
     rows = _adbc_fetchall(

--- a/tests/test_deltalake_export.py
+++ b/tests/test_deltalake_export.py
@@ -1677,3 +1677,33 @@ class TestExportViewToDeltalake:
         cols = set(flat.schema().to_arrow().names)
         assert "pt_position" in cols  # untouched binary column
         assert not any(c.endswith("_partition") for c in cols)
+
+
+class TestGeometryTypeRegistrationNotClobbered:
+    """Regression guard for the view-schema / WKB-passthrough bug.
+
+    ``PGDialect.ischema_names`` is a single process-global dict that geoalchemy2
+    populates with ``Geometry``.  This module used to alias ``geometry`` to
+    ``BYTEA`` in it at import time, which un-registered ``Geometry`` for the
+    entire process.  Because the Flask app imports this module transitively via
+    the Celery ``include`` list, reflected view columns then typed as ``BYTEA``,
+    so /views/schemas raised "Unsupported column type" and query_view returned
+    raw WKB instead of x/y/z.
+    """
+
+    def test_importing_deltalake_export_leaves_geometry_mapped_to_geometry(self):
+        # Importing the module under test is the action being guarded.
+        import materializationengine.workflows.deltalake_export  # noqa: F401
+        from geoalchemy2.types import Geometry
+        from sqlalchemy.dialects.postgresql import dialect as pg_dialect
+
+        assert pg_dialect.ischema_names["geometry"] is Geometry
+
+    def test_client_geometry_check_still_recognizes_reflected_type(self):
+        """The client keys off ``isinstance(column.type, Geometry)``."""
+        import materializationengine.workflows.deltalake_export  # noqa: F401
+        from geoalchemy2.types import Geometry
+        from sqlalchemy.dialects.postgresql import dialect as pg_dialect
+
+        reflected_type = pg_dialect.ischema_names["geometry"]()
+        assert isinstance(reflected_type, Geometry)

--- a/uv.lock
+++ b/uv.lock
@@ -1732,7 +1732,7 @@ wheels = [
 
 [[package]]
 name = "materializationengine"
-version = "5.26.2"
+version = "5.26.3"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-postgresql" },
@@ -1811,7 +1811,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=44.0.2" },
     { name = "deltalake", specifier = ">=1.5.0" },
     { name = "dynamicannotationdb", specifier = ">=5.13.1" },
-    { name = "emannotationschemas", specifier = "<=5.26.2" },
+    { name = "emannotationschemas", specifier = "<=5.26.3" },
     { name = "flask", specifier = ">=2.0.2,<3.0" },
     { name = "flask-accepts" },
     { name = "flask-admin" },
@@ -2335,7 +2335,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
This addresses a tricky bug in MaterializationEngine. 

Periodically, and its not clear when, we are getting a problem in the views, where the schema is givign a 500 error and queries fo the views are not converted the WKB columns in a view into positions. 

the schema error.. is something about a BYTEA conversion on the WKB columns.

https://minnie.microns-daf.com/materialize/api/v3/datastack/minnie65_phase3_v1/version/1885/views/schemas

here is an example... although right now this is not returning an error

Also the columns were also not getting converted when querying and were left in WKB format when using the query_view function of caveclient, which hits the query_view endpoint on MaterializationEngine. 

